### PR TITLE
Add wp-now tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
+        "@wp-now/dec-2023": "npm:@wp-now/wp-now@0.1.63",
+        "@wp-now/dec-2024": "npm:@wp-now/wp-now@0.1.74",
         "@wp-playground/cli": "^1.0.10"
       }
     },
@@ -678,6 +680,287 @@
         "undici-types": "~6.19.8"
       }
     },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="
+    },
+    "node_modules/@wp-now/dec-2023": {
+      "name": "@wp-now/wp-now",
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@wp-now/wp-now/-/wp-now-0.1.63.tgz",
+      "integrity": "sha512-b1bBThmCR3KRYczkcFm/sZpSYE3LAIybwHeMozwt4CDQdjnD2ixiZu3P7wcwD0pWpEGzyIDaFHsB9UK/uLk2MQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/node": "0.1.56",
+        "@php-wasm/universal": "0.1.56",
+        "@wp-playground/blueprints": "0.1.56",
+        "compressible": "2.0.18",
+        "compression": "1.7.4",
+        "express": "4.18.2",
+        "express-fileupload": "1.4.0",
+        "follow-redirects": "1.15.2",
+        "fs-extra": "11.1.1",
+        "unzipper": "0.10.11",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "wp-now": "with-node-version.js"
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/@php-wasm/node": {
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-0.1.56.tgz",
+      "integrity": "sha512-HcIPR8QnBgNsgys+msHktUICG+ENNn3Xt6kjP1OJKA0Yi/Y9bATEe8DJx3RiPyrVDJsb8WLKB+aWq9KVXl8x8w==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/universal": "0.1.56",
+        "@php-wasm/util": "0.1.56",
+        "comlink": "^4.4.1",
+        "express": "4.18.2",
+        "ws": "8.13.0",
+        "yargs": "17.7.2"
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/@php-wasm/universal": {
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-0.1.56.tgz",
+      "integrity": "sha512-qQCpYPrGdfh8PpaIUPOemMtw7bXCEBAThiAokIW5nu+51NRLK2y10Jpk2ce+/iOC9e6SLtpA6Hr2U8GrnPAXjA==",
+      "license": "GPL-2.0-or-later"
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/@php-wasm/util": {
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-0.1.56.tgz",
+      "integrity": "sha512-3UW9+kh9wZkWbcxBFv/qhYF8bzE2oPGSUzr0oDnnUJGDzCJnjL5OFcfU7WJD9lKTJ85F5+Hfbg3m/mOQIaniZQ=="
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/@wp-playground/blueprints": {
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-0.1.56.tgz",
+      "integrity": "sha512-Yvll3D8oLbLgFQLQfDxkgucyLLGi99L9wl0z4+MDmFg4hEegZfP1e+VhjcXHIH3if+2XjMsWKLbUvwwHudzJkg=="
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@wp-now/dec-2023/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wp-now/dec-2024": {
+      "name": "@wp-now/wp-now",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/@wp-now/wp-now/-/wp-now-0.1.74.tgz",
+      "integrity": "sha512-Id2DOqIyBnQ/zlzbA0gY70T/6/Jy+EjsiPeMave4emmCfg4DI8i3crrUXu8KLHNPUrUeAJIA/qpxCksg0KTtFQ==",
+      "dependencies": {
+        "@php-wasm/node": "0.6.16",
+        "@php-wasm/universal": "0.6.16",
+        "@webcontainer/env": "1.1.1",
+        "@wp-playground/blueprints": "0.6.16",
+        "compressible": "2.0.18",
+        "compression": "1.7.4",
+        "express": "4.19.2",
+        "follow-redirects": "1.15.6",
+        "fs-extra": "11.1.1",
+        "hpagent": "1.2.0",
+        "unzipper": "0.10.11",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "wp-now": "with-node-version.js"
+      }
+    },
+    "node_modules/@wp-now/dec-2024/node_modules/@php-wasm/node": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-0.6.16.tgz",
+      "integrity": "sha512-8G79CDlExmh3wvIyI6JensmfewJ+/+hhBZVBnVwKeoe5AuCxB4h/CChLklRm9sczx5ertiIlfkY3b9yWzD5Rfw==",
+      "dependencies": {
+        "@php-wasm/node-polyfills": "0.6.16",
+        "@php-wasm/universal": "0.6.16",
+        "@php-wasm/util": "0.6.16",
+        "comlink": "^4.4.1",
+        "ws": "8.13.0",
+        "yargs": "17.7.2"
+      },
+      "engines": {
+        "node": ">=18.18.0",
+        "npm": ">=8.11.0"
+      }
+    },
+    "node_modules/@wp-now/dec-2024/node_modules/@php-wasm/node-polyfills": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-0.6.16.tgz",
+      "integrity": "sha512-JurRxOkPa4tBeXI8kKFKdBzVmK3N2OQzSkti3bt76yWAeKFkvMCtYyEbvHkk6W64sP7bKRCyytPHvwjXNOI3ig=="
+    },
+    "node_modules/@wp-now/dec-2024/node_modules/@php-wasm/universal": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-0.6.16.tgz",
+      "integrity": "sha512-6zvhQ8yBFg+bp3m4+IAw4UdtLu/Vcq+7HHzmd9XenQWNkqd5GMvKADvpoYoFa6+B4x4ZVDf9M5o0h7Q5N2o1dQ==",
+      "engines": {
+        "node": ">=18.18.0",
+        "npm": ">=8.11.0"
+      }
+    },
+    "node_modules/@wp-now/dec-2024/node_modules/@php-wasm/util": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-0.6.16.tgz",
+      "integrity": "sha512-sSjsAsZ6NfH7NtefMLqgw5wJpZxWpu8U6aU0Ioa+Hp5gTndIOfqfB+1o8KSmXXB+J5foTiVLVE0+v3z8BdcliQ==",
+      "engines": {
+        "node": ">=18.18.0",
+        "npm": ">=8.11.0"
+      }
+    },
+    "node_modules/@wp-now/dec-2024/node_modules/@wp-playground/blueprints": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-0.6.16.tgz",
+      "integrity": "sha512-mKlmAPR8mBcz5azSlTZUzXEfFKDG7kHFUaA8wAUGpMN3BEsjMn0tje3t8R602WgSZCwHSeTXFHXTHtdPVXuvDg==",
+      "engines": {
+        "node": ">=18.18.0",
+        "npm": ">=8.11.0"
+      }
+    },
+    "node_modules/@wp-now/dec-2024/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wp-playground/blueprints": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-1.0.10.tgz",
@@ -918,6 +1201,11 @@
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "license": "MIT"
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -943,6 +1231,31 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -973,6 +1286,15 @@
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/btoa-lite": {
       "version": "1.0.0",
@@ -1010,6 +1332,33 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1036,6 +1385,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/clean-git-ref": {
@@ -1091,6 +1451,52 @@
       "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
       "license": "Apache-2.0"
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/compression/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1126,6 +1532,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -1210,6 +1621,41 @@
       "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
       "integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
       "license": "MIT"
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -1337,6 +1783,18 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-fileupload": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.4.0.tgz",
+      "integrity": "sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1359,6 +1817,25 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/forwarded": {
@@ -1391,6 +1868,26 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -1428,6 +1925,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -1496,6 +2013,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1562,6 +2087,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1594,6 +2129,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1661,6 +2201,11 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -1783,6 +2328,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -1799,6 +2355,17 @@
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -1861,6 +2428,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1885,6 +2460,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -1902,6 +2485,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1994,6 +2582,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/safe-buffer": {
@@ -2096,6 +2696,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2187,6 +2792,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2229,6 +2842,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -2282,6 +2903,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
-    "@wp-playground/cli": "^1.0.10"
+    "@wp-playground/cli": "^1.0.10",
+    "@wp-now/dec-2024": "npm:@wp-now/wp-now@0.1.74",
+    "@wp-now/dec-2023": "npm:@wp-now/wp-now@0.1.63"
   }
 }

--- a/scripts/lib/log-parser/parse-raw-logs.sh
+++ b/scripts/lib/log-parser/parse-raw-logs.sh
@@ -141,6 +141,26 @@ parse_raw_logs() {
                         "details": $line,
                         "log": $input
                     }]
+                elif ($line | test("^npm error")) then
+                    . + [{
+                        "message": "",
+                        "level": "FATAL",
+                        "type": "PLAYGROUND",
+                        "test": $test_name,
+                        ($item_type): $item_name,
+                        "details": $line,
+                        "log": $input
+                    }]
+                elif ($line | test("^Error when executing the blueprint step")) then
+                    . + [{
+                        "message": "",
+                        "level": "FATAL",
+                        "type": "PLAYGROUND",
+                        "test": $test_name,
+                        ($item_type): $item_name,
+                        "details": $line,
+                        "log": $input
+                    }]
                 elif length > 0 then
                     .[:-1] + [(last | .details += (if .details == "" then "" else "\n" end) + $line)]
                 else

--- a/scripts/lib/playground-tests/wp-now-dec-2023.sh
+++ b/scripts/lib/playground-tests/wp-now-dec-2023.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+source "./scripts/pre-script-run.sh"
+source "./scripts/lib/playground-tests/wp-now.sh"
+
+wp_now_test --wp-now="./node_modules/@wp-now/dec-2023/cli.js" "$@"

--- a/scripts/lib/playground-tests/wp-now.sh
+++ b/scripts/lib/playground-tests/wp-now.sh
@@ -3,7 +3,9 @@
 source "./scripts/pre-script-run.sh"
 
 stop_wp_now() {
-    kill -SIGKILL $1
+    if [ -n "$1" ] && kill -0 "$1" 2>/dev/null; then
+        kill -SIGKILL "$1" > /dev/null 2>&1 || true
+    fi
 }
 
 print_wp_now_output() {

--- a/scripts/lib/playground-tests/wp-now.sh
+++ b/scripts/lib/playground-tests/wp-now.sh
@@ -1,0 +1,106 @@
+#! /bin/bash
+
+source "./scripts/pre-script-run.sh"
+
+stop_wp_now() {
+    kill -SIGKILL $1
+}
+
+print_wp_now_output() {
+    grep "^Failed to start the server:" "$1" \
+        | sed 's/^Failed to start the server: //'
+}
+
+wp_now_test() {
+    local blueprint_path=""
+    local wordpress_path=""
+    # Parse command line options
+    while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --blueprint)
+        blueprint_path="$2"
+        shift 2
+        ;;
+        --wordpress)
+        wordpress_path="$2"
+        shift 2
+        ;;
+        *)
+        echo "Invalid option: $1" >&2
+        exit 1
+        ;;
+    esac
+    done
+
+    if [ -z "$blueprint_path" ]; then
+        exit 1
+    fi
+
+    local wp_now_compatible_blueprint=$(mktemp)
+
+    # WP-NOW doesn't support the latest Blueprint format, so we need to convert
+    # pluginData to pluginZipFile and themeData to themeZipFile if they exist
+    jq '
+      .steps = (.steps | map(
+        if .step == "installPlugin" then
+          [
+            {
+              step: .step,
+              pluginZipFile: .pluginData,
+              options: .options
+            }
+          ]
+        elif .step == "installTheme" then
+          [
+            {
+              step: .step,
+              themeZipFile: .themeData,
+              options: .options
+            }
+          ]
+        else
+          .
+        end
+      ) | flatten)
+    ' "$blueprint_path" > "$wp_now_compatible_blueprint"
+
+    # Start WP-NOW in the background and capture its output
+    local wp_now_output_log=$(mktemp)
+    node ./node_modules/@wp-now/dec-2024/cli.js start \
+        --php=8.0 \
+        --blueprint="$wp_now_compatible_blueprint" \
+        --skip-browser \
+        > "$wp_now_output_log" 2>&1 &
+    local wp_now_pid=$!
+
+    trap "stop_wp_now $wp_now_pid" EXIT
+
+    # Monitor the output for success or failure
+    local timeout=30
+    local start_time=$SECONDS
+    while [ $(( SECONDS - start_time )) -lt $timeout ]; do
+        if [ ! -f "$wp_now_output_log" ]; then
+            sleep 1
+            continue
+        fi
+
+        while IFS= read -r line; do
+            if [[ "$line" == "Server running at"* ]]; then
+                stop_wp_now $wp_now_pid
+                exit 0
+            elif [[ "$line" == "Failed to start the server"* ]]; then
+                stop_wp_now $wp_now_pid
+                print_wp_now_output "$wp_now_output_log"
+                exit 1
+            fi
+        done < "$wp_now_output_log"
+
+        sleep 1
+    done
+
+    stop_wp_now $wp_now_pid
+    cat "$wp_now_output_log"
+    exit 1
+}
+
+wp_now_test "$@"

--- a/scripts/unit-tests/test-run-tests.sh
+++ b/scripts/unit-tests/test-run-tests.sh
@@ -7,16 +7,22 @@ source "./scripts/pre-script-run.sh"
 source "$PLAYGROUND_TESTER_PATH/scripts/unit-tests/common-test-functions.sh"
 
 run_test "Test a successful theme run"\
-    "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/google-maps-effortless --wordpress ./temp/wordpress" \
-    "✗ google-maps-effortless failed asyncify-boot
-✗ google-maps-effortless failed jspi-boot"
+    "./scripts/run-tests.sh --theme $PLAYGROUND_TESTER_DATA_PATH/logs/themes/1/100-bytes --wordpress ./temp/wordpress" \
+    "✓ 100-bytes passed asyncify-boot
+✓ 100-bytes passed jspi-boot
+✓ 100-bytes passed wp-now
+✓ 100-bytes passed wp-now-dec-2023"
 
 run_test "Test a successful plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/0/0gravatar --wordpress ./temp/wordpress" \
     "✓ 0gravatar passed asyncify-boot
-✓ 0gravatar passed jspi-boot"
+✓ 0gravatar passed jspi-boot
+✓ 0gravatar passed wp-now
+✓ 0gravatar passed wp-now-dec-2023"
 
 run_test "Test a failed plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/google-maps-effortless --wordpress ./temp/wordpress" \
     "✗ google-maps-effortless failed asyncify-boot
-✗ google-maps-effortless failed jspi-boot"
+✗ google-maps-effortless failed jspi-boot
+✗ google-maps-effortless failed wp-now
+✗ google-maps-effortless failed wp-now-dec-2023"

--- a/scripts/unit-tests/test-run-tests.sh
+++ b/scripts/unit-tests/test-run-tests.sh
@@ -10,19 +10,19 @@ run_test "Test a successful theme run"\
     "./scripts/run-tests.sh --theme $PLAYGROUND_TESTER_DATA_PATH/logs/themes/1/100-bytes --wordpress ./temp/wordpress" \
     "✓ 100-bytes passed asyncify-boot
 ✓ 100-bytes passed jspi-boot
-✓ 100-bytes passed wp-now
-✓ 100-bytes passed wp-now-dec-2023"
+✓ 100-bytes passed wp-now-dec-2023
+✓ 100-bytes passed wp-now"
 
 run_test "Test a successful plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/0/0gravatar --wordpress ./temp/wordpress" \
     "✓ 0gravatar passed asyncify-boot
 ✓ 0gravatar passed jspi-boot
-✓ 0gravatar passed wp-now
-✓ 0gravatar passed wp-now-dec-2023"
+✓ 0gravatar passed wp-now-dec-2023
+✓ 0gravatar passed wp-now"
 
 run_test "Test a failed plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/google-maps-effortless --wordpress ./temp/wordpress" \
     "✗ google-maps-effortless failed asyncify-boot
 ✗ google-maps-effortless failed jspi-boot
-✗ google-maps-effortless failed wp-now
-✗ google-maps-effortless failed wp-now-dec-2023"
+✗ google-maps-effortless failed wp-now-dec-2023
+✗ google-maps-effortless failed wp-now"


### PR DESCRIPTION
This PR adds two WP-now tests that will boot Playground using a version of WP-now from December 2024, and December 2023. It also adds a report that compares how Playground improved between WP-now versions and a way.

The goal of these tests is to show how Playground improved over the last year by producing a report comparing the number of plugins that failed to boot in 2023 and 2024. 

To run this report the batch runner now supports a `--top` flag that will run tests for the top N items from WordPress.org.