### PR TITLE
Performance improvements

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -18,9 +18,7 @@ runs:
 
     - name: Git Submodule Update
       shell: bash
-      run: |
-        git pull --recurse-submodules origin ${{ github.event.pull_request.head.ref }}
-        git submodule update --remote --recursive
+      run: git submodule update --remote --recursive --depth 1
 
     - name: Set Node version
       shell: bash

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -35,6 +35,6 @@ jobs:
         run: |
           BATCH_SIZE=${{ inputs.batch_size }}
           if [ -z "$BATCH_SIZE" ]; then
-            BATCH_SIZE=50
+            BATCH_SIZE=150
           fi
           ./scripts/run-batch.sh --batch-size $BATCH_SIZE --plugins

--- a/.github/workflows/test-themes.yml
+++ b/.github/workflows/test-themes.yml
@@ -35,6 +35,6 @@ jobs:
         run: |
           BATCH_SIZE=${{ inputs.batch_size }}
           if [ -z "$BATCH_SIZE" ]; then
-            BATCH_SIZE=50
+            BATCH_SIZE=150
           fi
           ./scripts/run-batch.sh --batch-size $BATCH_SIZE --themes

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To see the exact errors generated Playground tests, check out [SQL Errors Report
 
 1. Clone the repository:
    ```
-   git clone --recurse-submodules https://github.com/bgrgicak/playground-tester.git
+   git clone --recurse-submodules --shallow-submodules https://github.com/bgrgicak/playground-tester.git
    ```
 2. Install dependencies:
    ```

--- a/scripts/build-wordpress.sh
+++ b/scripts/build-wordpress.sh
@@ -32,3 +32,9 @@ node "$PLAYGROUND_CLI_PATH" build-snapshot \
     --outfile="$zip_path" > /dev/null
 unzip -qq "$zip_path" -d "$wordpress_path" > /dev/null 2>&1
 rm "$zip_path"
+
+# Initialize the WordPress snapshot as a git repository,
+# so we can reset any file changes before every test.
+git init "$wordpress_path" > /dev/null 2>&1
+git -C "$wordpress_path" add . > /dev/null 2>&1
+git -C "$wordpress_path" commit -m "WordPress snapshot" > /dev/null 2>&1

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -73,12 +73,10 @@ for test in scripts/lib/playground-tests/*.sh; do
     fi
     echo "" > "$log_file"
 
-    # Each test gets its own copy of WordPress.
-    # This ensures each test starts with a clean WordPress installation.
-    temp_folder=$(mktemp -d)
-    cp -r "$wordpress_path" "$temp_folder/wordpress"
+    # Ensure each test starts with a clean WordPress installation.
+    git -C "$wordpress_path" reset --hard > /dev/null 2>&1
 
-    result=$(./$test --blueprint $blueprint_path --wordpress $temp_folder/wordpress)
+    result=$(./$test --blueprint "$blueprint_path" --wordpress "$wordpress_path")
 
     # if result is empty, add empty log file
     # We use empty log file to indicate that the test passed

--- a/scripts/unit-tests/test-run-tests.sh
+++ b/scripts/unit-tests/test-run-tests.sh
@@ -8,15 +8,18 @@ source "$PLAYGROUND_TESTER_PATH/scripts/unit-tests/common-test-functions.sh"
 
 run_test "Test a successful theme run"\
     "./scripts/run-tests.sh --theme $PLAYGROUND_TESTER_DATA_PATH/logs/themes/g/100-bytes --wordpress ./temp/wordpress" \
-    "✓ 100-bytes passed asyncify-boot
+    "✓ 100-bytes passed ast-sqlite-boot
+✓ 100-bytes passed asyncify-boot
 ✓ 100-bytes passed jspi-boot"
 
 run_test "Test a successful plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/0/0gravatar --wordpress ./temp/wordpress" \
-    "✓ 0gravatar passed asyncify-boot
+    "✓ 0gravatar passed ast-sqlite-boot
+✓ 0gravatar passed asyncify-boot
 ✓ 0gravatar passed jspi-boot"
 
 run_test "Test a failed plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/google-maps-effortless --wordpress ./temp/wordpress" \
-    "✗ google-maps-effortless failed asyncify-boot
-✗ google-maps-effortless failed jspi-boot"
+    "✗ gl-import-external-images failed ast-sqlite-boot
+✗ gl-import-external-images failed asyncify-boot
+✗ gl-import-external-images failed jspi-boot"

--- a/scripts/unit-tests/test-run-tests.sh
+++ b/scripts/unit-tests/test-run-tests.sh
@@ -19,7 +19,7 @@ run_test "Test a successful plugin run"\
 ✓ 0gravatar passed jspi-boot"
 
 run_test "Test a failed plugin run"\
-    "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/google-maps-effortless --wordpress ./temp/wordpress" \
+    "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/gl-import-external-images --wordpress ./temp/wordpress" \
     "✗ gl-import-external-images failed ast-sqlite-boot
 ✗ gl-import-external-images failed asyncify-boot
 ✗ gl-import-external-images failed jspi-boot"


### PR DESCRIPTION
This PR aims to improve the performance of Playground Tester runs on the CI.

It adds the following improvements:
1. The WordPress snapshot is initialized as a Git repository and before every test, `git reset --hard` is used to start with a clean setup. This should noticeably improve the performance of running the plugin/theme tests.
2. Updating submodules to their latest remote commit is done only using `git submodule update --remote --recursive --depth 1`. Locally, this seems to run much faster than the `git pull` (that was likely fetching the repo history).
3. I increased the batch sizes by 3x. If we see the runs are fast-enough, we can try more.