### PR TITLE
Parallelize test jobs

### DIFF
--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -18,6 +18,13 @@ permissions:
 jobs:
   run-scripts:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        range:
+          - { from: "0", to: "b" }
+          - { from: "c", to: "n" }
+          - { from: "o", to: "z" }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,4 +44,4 @@ jobs:
           if [ -z "$BATCH_SIZE" ]; then
             BATCH_SIZE=150
           fi
-          ./scripts/run-batch.sh --batch-size $BATCH_SIZE --plugins
+          ./scripts/run-batch.sh --batch-size $BATCH_SIZE --plugins --from-letter ${{ matrix.range.from }} --to-letter ${{ matrix.range.to }}

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         range:
-          - { from: "0", to: "b" }
-          - { from: "c", to: "n" }
-          - { from: "o", to: "z" }
+          - "_0123456789ab"
+          - "cdefghijklmn"
+          - "opqrstuvwxyz"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,4 +44,4 @@ jobs:
           if [ -z "$BATCH_SIZE" ]; then
             BATCH_SIZE=150
           fi
-          ./scripts/run-batch.sh --batch-size $BATCH_SIZE --plugins --from-letter ${{ matrix.range.from }} --to-letter ${{ matrix.range.to }}
+          ./scripts/run-batch.sh --batch-size $BATCH_SIZE --plugins --prefix-chars ${{ matrix.range }}

--- a/scripts/lib/log-parser/analyze-json-logs.sh
+++ b/scripts/lib/log-parser/analyze-json-logs.sh
@@ -9,44 +9,35 @@ source "./scripts/pre-script-run.sh"
 # All find parameters are supported
 #
 # Usage:
-#   get_log_files <item-type> [--from-letter <letter>] [--to-letter <letter>] [<find-args>...]
+#   get_log_files <item-type> [--prefix-chars <prefix-chars>] [<find-args>...]
 get_log_files() {
-    local item_type="$1"
-    shift
-    local from_letter="0"
-    local to_letter="z"
+	local positional_args=()
+	local prefix_chars="*"
+	while [[ "$#" -gt 0 ]]; do
+		case $1 in
+			--prefix-chars)
+			prefix_chars="$2"
+			shift 2
+			;;
+			*)
+			positional_args+=("$1")
+			shift 1
+			;;
+		esac
+	done
+	local item_type="${positional_args[0]}"
+	local find_args=("${positional_args[@]:1}")
 
-    # Parse named arguments
-    while [[ "$#" -gt 0 ]]; do
-        case $1 in
-            --from-letter)
-                from_letter="$2"
-                shift 2
-                ;;
-            --to-letter)
-                to_letter="$2" 
-                shift 2
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
+	# Get a list of paths to search in
+	local prefixes=($(ls -1 "$PLAYGROUND_TESTER_DATA_PATH/logs/$item_type"))
+	local paths=()
+	for prefix in "${prefixes[@]}"; do
+		if [[ "$prefix_chars" == "*" ]] || [[ "$prefix_chars" == *"$prefix"* ]]; then
+			paths+=("$PLAYGROUND_TESTER_DATA_PATH/logs/$item_type/$prefix")
+		fi
+	done
 
-    # Set default range if not specified
-    from_letter="${from_letter:-0}"
-    to_letter="${to_letter:-z}"
-
-    # Generate a list of paths to search in based on the from and to letters
-    local chars=(0 1 2 3 4 5 6 7 8 9 a b c d e f g h i j k l m n o p q r s t u v w x y z)
-    local paths=()
-    for letter in "${chars[@]}"; do
-        if [[ "$letter" > "$from_letter" || "$letter" = "$from_letter" ]] && [[ "$letter" < "$to_letter" || "$letter" = "$to_letter" ]]; then
-            paths+=("$PLAYGROUND_TESTER_DATA_PATH/logs/$item_type/$letter")
-        fi
-    done
-
-    find "${paths[@]}" -mindepth 2 -maxdepth 2 -type f "$@"
+	find "${paths[@]}" -mindepth 2 -maxdepth 2 -type f "${find_args[@]}"
 }
 
 # Get log files with errors
@@ -56,15 +47,15 @@ get_log_files() {
 # Usage:
 #   get_log_files_with_errors <item-type> <limit>
 get_log_files_with_errors() {
-    local item_type="$1"
-    local limit="$2"
-    if [ -z "$limit" ]; then
-        shift
-        get_log_files "$item_type" -name "error.json" -size +3c "$@"
-    else
-        shift 2
-        get_log_files "$item_type" -name "error.json" -size +3c "$@" | head -n "$limit"
-    fi
+	local item_type="$1"
+	local limit="$2"
+	if [ -z "$limit" ]; then
+		shift
+		get_log_files "$item_type" -name "error.json" -size +3c "$@"
+	else
+		shift 2
+		get_log_files "$item_type" -name "error.json" -size +3c "$@" | head -n "$limit"
+	fi
 }
 
 # Get all errors of a given level from the JSON log file
@@ -72,9 +63,9 @@ get_log_files_with_errors() {
 # Usage:
 #   get_errors_by_level <level> <log-file>
 get_errors_by_level() {
-    local level="$1"
-    local log_file="$2"
-    jq '[.[] | select(.level == "'"$level"'")]' "$log_file"
+	local level="$1"
+	local log_file="$2"
+	jq '[.[] | select(.level == "'"$level"'")]' "$log_file"
 }
 
 # Get the number of errors of a given level from the JSON log file
@@ -82,7 +73,7 @@ get_errors_by_level() {
 # Usage:
 #   get_number_of_errors_by_level <level> <log-file>
 get_number_of_errors_by_level() {
-    echo "$(get_errors_by_level "$1" "$2" | jq 'length')"
+	echo "$(get_errors_by_level "$1" "$2" | jq 'length')"
 }
 
 # Get the first n logs to test.
@@ -92,18 +83,29 @@ get_number_of_errors_by_level() {
 # file located in log directories of each item.
 #
 # Usage:
-#   get_first_n_logs_to_test <item-type> <batch-size>
-#   get_first_n_logs_to_test <item-type> <batch-size> <from-letter> <to-letter>
+#   get_first_n_logs_to_test <item-type> <batch-size> [--prefix-chars <prefix-chars>]
 get_first_n_logs_to_test() {
-    local item_type="$1"
-    local batch_size="$2"
-    local from_letter="${3:-0}"
-    local to_letter="${4:-z}"
+	local positional_args=()
+	local prefix_chars="*"
+	while [[ "$#" -gt 0 ]]; do
+		case $1 in
+			--prefix-chars)
+			prefix_chars="$2"
+			shift 2
+			;;
+			*)
+			positional_args+=("$1")
+			shift 1
+			;;
+		esac
+	done
+	local item_type="${positional_args[0]}"
+	local batch_size="${positional_args[1]}"
 
-    local all_log_files=$(get_log_files "$item_type" --from-letter "$from_letter" --to-letter "$to_letter" -name "*last-tested.txt"|
-        awk -F'/' '{print $NF " " substr($0, 1, length($0)-length($NF)-1)}' |
-        sort |
-        cut -d' ' -f2-)
-    echo "$all_log_files" |
-        head -n "$batch_size"
+	local all_log_files=$(get_log_files "$item_type" --prefix-chars "$prefix_chars" -name "*last-tested.txt"|
+		awk -F'/' '{print $NF " " substr($0, 1, length($0)-length($NF)-1)}' |
+		sort |
+		cut -d' ' -f2-)
+	echo "$all_log_files" |
+		head -n "$batch_size"
 }

--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -35,18 +35,10 @@ while [[ "$#" -gt 0 ]]; do
       item_type="themes"
       shift 1
       ;;
-    --from-letter)
-      from_letter="$2"
-      if ! [[ "$from_letter" =~ ^[a-z0-9]$ ]] ; then
-        echo "Error: --from-letter argument must be a single lowercase alphanumeric character" >&2
-        exit 1
-      fi
-      shift 2
-      ;;
-    --to-letter)
-      to_letter="$2"
-      if ! [[ "$to_letter" =~ ^[a-z0-9]$ ]] ; then
-        echo "Error: --to-letter argument must be a single lowercase alphanumeric character" >&2
+    --prefix-chars)
+      prefix_chars="$2"
+      if ! [[ "$prefix_chars" =~ ^[_a-z0-9]+$ ]] ; then
+        echo "Error: --prefix-chars must consist of lowercase alphanumeric characters" >&2
         exit 1
       fi
       shift 2
@@ -58,9 +50,8 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-# Set default range if not specified
-from_letter="${from_letter:-0}"
-to_letter="${to_letter:-z}"
+# Set full range if not specified
+prefix_chars="${prefix_chars:-*}"
 
 download_latest_wordpress() {
   if [ -d "$PLAYGROUND_TESTER_WORDPRESS_PATH" ]; then
@@ -74,7 +65,7 @@ run_batch() {
 
     # Find the oldest items to test first.
     echo "[DEBUG]: Starting get_first_n_logs_to_test"
-    local folders=$(get_first_n_logs_to_test "$item_type" "$batch_size" "$from_letter" "$to_letter")
+    local folders=$(get_first_n_logs_to_test "$item_type" "$batch_size" --prefix-chars "$prefix_chars")
     echo "[DEBUG]: Done get_first_n_logs_to_test"
 
     # Update all items in the current batch to prevent them from being picked up by another runner.

--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -35,12 +35,32 @@ while [[ "$#" -gt 0 ]]; do
       item_type="themes"
       shift 1
       ;;
+    --from-letter)
+      from_letter="$2"
+      if ! [[ "$from_letter" =~ ^[a-z0-9]$ ]] ; then
+        echo "Error: --from-letter argument must be a single lowercase alphanumeric character" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --to-letter)
+      to_letter="$2"
+      if ! [[ "$to_letter" =~ ^[a-z0-9]$ ]] ; then
+        echo "Error: --to-letter argument must be a single lowercase alphanumeric character" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     *)
       echo "Invalid option: $1" >&2
       exit 1
       ;;
   esac
 done
+
+# Set default range if not specified
+from_letter="${from_letter:-0}"
+to_letter="${to_letter:-z}"
 
 download_latest_wordpress() {
   if [ -d "$PLAYGROUND_TESTER_WORDPRESS_PATH" ]; then
@@ -54,7 +74,7 @@ run_batch() {
 
     # Find the oldest items to test first.
     echo "[DEBUG]: Starting get_first_n_logs_to_test"
-    local folders=$(get_first_n_logs_to_test "$item_type" "$batch_size")
+    local folders=$(get_first_n_logs_to_test "$item_type" "$batch_size" "$from_letter" "$to_letter")
     echo "[DEBUG]: Done get_first_n_logs_to_test"
 
     # Update all items in the current batch to prevent them from being picked up by another runner.


### PR DESCRIPTION
This adds a `--prefix chars <chars>` parameter that can be used to test only a subset of plugins or themes and can be used for parallelization:

```bash
./scripts/run-batch.sh --batch-size 100 --plugins --prefix-chars abcdefg
```

For now, it's activating this for plugins, trying a matrix of 3 workers.