### PR TITLE
Speedups using sparse checkout

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -16,9 +16,9 @@ runs:
         GH_USER: ${{ env.GH_USER }}
         GH_TOKEN: ${{ env.GH_TOKEN }}
 
-    - name: Git Submodule Update
+    - name: Checkout data submodule
       shell: bash
-      run: git submodule update --remote --recursive --depth 1
+      run: git submodule update --init --remote --recursive --depth 1 data
 
     - name: Set Node version
       shell: bash

--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -9,9 +9,7 @@ runs:
       run: |
         git config --global user.name "${{ env.GH_USER }}"
         git config --global user.email "${{ env.GH_USER }}@users.noreply.github.com"
-        cd data/
-        git remote set-url origin https://${{ env.GH_USER }}:${{ env.GH_TOKEN }}@github.com/bgrgicak/Playground-compatibility-reports.git
-        cd ..
+        git -C data remote set-url origin https://${{ env.GH_USER }}:${{ env.GH_TOKEN }}@github.com/bgrgicak/Playground-compatibility-reports.git
       env:
         GH_USER: ${{ env.GH_USER }}
         GH_TOKEN: ${{ env.GH_TOKEN }}

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.BOTBERO_TOKEN }}
 

--- a/.github/workflows/run-tests-on-pr.yml
+++ b/.github/workflows/run-tests-on-pr.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.BOTBERO_TOKEN }}
 
@@ -24,6 +23,10 @@ jobs:
         env:
           GH_USER: ${{ secrets.BOTBERO_USER }}
           GH_TOKEN: ${{ secrets.BOTBERO_TOKEN }}
+
+      - name: Checkout wp-public-data submodule
+        shell: bash
+        run: git submodule update --init --remote --recursive --depth 1 wp-public-data
 
       - name: Run tests
         run: |

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.BOTBERO_TOKEN }}
 

--- a/.github/workflows/test-themes.yml
+++ b/.github/workflows/test-themes.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.BOTBERO_TOKEN }}
 

--- a/.github/workflows/update-available-themes-and-plugins.yml
+++ b/.github/workflows/update-available-themes-and-plugins.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.BOTBERO_TOKEN }}
 
@@ -21,6 +20,10 @@ jobs:
         env:
           GH_USER: ${{ secrets.BOTBERO_USER }}
           GH_TOKEN: ${{ secrets.BOTBERO_TOKEN }}
+
+      - name: Checkout wp-public-data submodule
+        shell: bash
+        run: git submodule update --init --remote --recursive --depth 1 wp-public-data
 
       - name: Run update-available-themes-and-plugins.sh
         run: ./scripts/update-available-themes-and-plugins.sh

--- a/.github/workflows/update-error-stats-data.yml
+++ b/.github/workflows/update-error-stats-data.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.BOTBERO_TOKEN }}
 

--- a/scripts/run-batch.sh
+++ b/scripts/run-batch.sh
@@ -66,6 +66,15 @@ run_batch() {
     # Find the oldest items to test first.
     local folders=$(get_first_n_logs_to_test "$item_type" "$batch_size" --prefix-chars "$prefix_chars")
 
+    # Sparse-checkout data to only the selected folders.
+    # This will speed up commits when running the tests.
+    git -C "$PLAYGROUND_TESTER_DATA_PATH" sparse-checkout init --cone
+    local paths=()
+    for folder in $folders; do
+      paths+=("${folder#$PLAYGROUND_TESTER_DATA_PATH/}")
+    done
+    git -C "$PLAYGROUND_TESTER_DATA_PATH" sparse-checkout set "${paths[@]}"
+
     # Update all items in the current batch to prevent them from being picked up by another runner.
     #
     # We will only replace the TIMESTAMP-last-tested.txt file to indicate that the item is being processed.


### PR DESCRIPTION
This PR tries to further speed up the plugin & theme tests by:
1. Checking out only the `data` submodule where possible.
2. Using sparse checkout only for the tested plugins (this should speed up the git commit commands).