### PR TITLE
Test fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,11 @@
     "": {
       "dependencies": {
         "@types/yargs": "^17.0.33",
-        "@wp-playground/cli": "^1.0.28",
+        "@wp-playground/cli": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-cli-1.0.30.tar.gz",
         "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": "23.11.0"
       }
     },
     "node_modules/@octokit/app": {
@@ -524,175 +527,175 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-1.0.28.tgz",
-      "integrity": "sha512-0f8pMoq8vbQSF0UNHtPcizBcXhwEmnJKS/O44/mF0FYFfl+lAtrkfTQtr/h2AkbiCsVXRGwJsaWVrRBSuk51/g==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-fs-journal-1.0.30.tar.gz",
+      "integrity": "sha512-i9UGRmwiS+8ie36HJgleeq/kjYyScMvbFdNoXlS3Jq6zqEs2EYKNmXlcq1p1la91vIVaUqPpmE3SzWUfldtNow==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node": "1.0.28",
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
         "comlink": "^4.4.1",
         "events": "3.3.0",
-        "express": "4.19.2",
+        "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-1.0.28.tgz",
-      "integrity": "sha512-Mw8tGlPkYKLmmRJyzfpquqUDQYyHMG6c+pw2BFhljJQ0l7eQDmJOd79aZfbWcnY6DBbs5cNFhSnOsP4JLJbXXQ==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+      "integrity": "sha512-PBbISiGnB2oxoxG+kHv1/U825aeDwabRQ708wKjdsb6zkAhOiWsBWaOUOwZouh5p5QnVTJH/rDI4v97Vz2dN6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "1.0.28"
+        "@php-wasm/node-polyfills": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-1.0.28.tgz",
-      "integrity": "sha512-1R5a7d9Gn83viF3SVbt3pMbzC4DambJu64OZfS+i19HkbFeuKCNaqUzQtmDsAXzrtNJCNRYVrVpgVtwNwPDBcQ==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-1.0.30.tar.gz",
+      "integrity": "sha512-Z/exOQ2PgGzL8Vqz5yltwh25BN+9EMA54HBMsVagnJG9oGgyXKIGgKzKdT+BMxZ/bGL3BE8ryAE/8oXXNv6ZYw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node-polyfills": "1.0.28",
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
-        "@wp-playground/common": "1.0.28",
-        "@wp-playground/wordpress": "1.0.28",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node-polyfills": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
+        "@wp-playground/common": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-common-1.0.30.tar.gz",
+        "@wp-playground/wordpress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-wordpress-1.0.30.tar.gz",
         "comlink": "^4.4.1",
         "events": "3.3.0",
-        "express": "4.19.2",
+        "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/node-polyfills": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-1.0.28.tgz",
-      "integrity": "sha512-pgmKP1weCeFxmOdeN1LFIRHe3L2KLEb83VPE/1/1GEwHEXMPoCF/PZGCFifkG28O8uDBdDF+RjoKe7XF0ETW6A==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz",
+      "integrity": "sha512-3iz7dEdpPUm1mUoyEwtybSCRzycCsIxod2gSA4Dnc18PBuyeO8jBZE+XZt/ULZlqIyV35fSBGBKvUNRUqd5CUg==",
       "license": "GPL-2.0-or-later"
     },
     "node_modules/@php-wasm/progress": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-1.0.28.tgz",
-      "integrity": "sha512-8V7PGK81R72X/Nr38QZqgDgPE5kNQZWjMQSpWhpQQeqxH6KpmjdA190snWm9HyWjr5/JIsCaMeKaIoj2dydHrw==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-progress-1.0.30.tar.gz",
+      "integrity": "sha512-sH1Fegyzb7Xz+yDyzyfSQjhek11PtD9FBvOZeXDCePEG7ZXlTB4050AHWjdqF5H6KQ0XiL27SFPuGiuGWSFbKQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node-polyfills": "1.0.28"
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node-polyfills": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-1.0.28.tgz",
-      "integrity": "sha512-NWB5u/Bv6bhhNeG4Zxx6LVix6GeKhwu+HQANiuub6gRHxTpdV5D/slJkRrgfmQEAC9Y3LF25lvHKrT8pFL9eLA==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-scopes-1.0.30.tar.gz",
+      "integrity": "sha512-T9eQoX5RS2SXaMEW0IgThg9xSMqLsVYJnqiyKO7bnRw5k+77BZgS+uFzisI62M9G6ocvoVspFtCYViD9jDHQIg==",
       "license": "GPL-2.0-or-later",
       "engines": {
-        "node": ">=16.15.1",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-1.0.28.tgz",
-      "integrity": "sha512-LLh3sRf6mDuENEBPXLE8362QJiVYn/z2bzK1ZcyeTb8SOu99N1JPBqz3PUApgN80IXhwraLm2o3W+mmHoRPqLg==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-stream-compression-1.0.30.tar.gz",
+      "integrity": "sha512-tU8FT+OE4n433pGnYcfvmkT2sGcXwijVX0Q/VnoMQ3PCzYShJx5EzPGTDiMbNkWKMTNuwLh5p+ZuYpbx2K2y6g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "1.0.28",
-        "@php-wasm/util": "1.0.28"
+        "@php-wasm/node-polyfills": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-1.0.28.tgz",
-      "integrity": "sha512-F9N8oVhOnj8EsdWjj0Do7nwHVJXE0qDw4tcrFp6LKcXaw2JmD54HJY1TlqCNvVYpmd60/XmkMmsbcs8ILrVTDA==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+      "integrity": "sha512-iAWBQb+8G9R6N0jkdGuAKEHEeHcW6YLYImkBBcuJv0mMji8DzPG84z/ThmWz24UpA5tt5bDcsYQQofqNL9LKPA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node-polyfills": "1.0.28",
-        "@php-wasm/progress": "1.0.28",
-        "@php-wasm/stream-compression": "1.0.28",
-        "@php-wasm/util": "1.0.28",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node-polyfills": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz",
+        "@php-wasm/progress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-progress-1.0.30.tar.gz",
+        "@php-wasm/stream-compression": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-stream-compression-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
         "comlink": "^4.4.1",
         "ini": "4.1.2"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-1.0.28.tgz",
-      "integrity": "sha512-MhWQfkK4rADj/nYEeGX6Sbip3UeabtovHMIg4naQVPuUJqDkayO9pT61A31GX0A6iYS3RxkriLZuQImuCp/zTg==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
+      "integrity": "sha512-KJPuHsIarXqmOLZyDU7w4vwwZwgkchJmmv4oyVMHc4TZQnAHmlg5rL+TYjxfo7vSZqZJAnyLVAzjM6umAs3Q0Q==",
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/web": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-1.0.28.tgz",
-      "integrity": "sha512-xyEibkxelsJKmi3PqM1gsyj5R71/LP0W3m7osyVtFfqWQZbKRPy6tnet9AKvHur2XGAACswQP5mvopyUaLmmWA==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-web-1.0.30.tar.gz",
+      "integrity": "sha512-0Xi4QPp0SlKQivS3zfFwOATzAAROyPu0SIk8sc7DCwbPi30UYomafHFSN7LsdEHnFOOqSzXE1UJEObqRggD0ig==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "1.0.28",
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
-        "@php-wasm/web-service-worker": "1.0.28",
+        "@php-wasm/fs-journal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-fs-journal-1.0.30.tar.gz",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
+        "@php-wasm/web-service-worker": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-web-service-worker-1.0.30.tar.gz",
         "comlink": "^4.4.1",
         "events": "3.3.0",
-        "express": "4.19.2",
+        "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=16.15.1",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-1.0.28.tgz",
-      "integrity": "sha512-UoXuRKBTi432jJFGakKTz14f0VdG8kGTgB3N4IcI30ukbCnOXpvViVEXQ6KW60BatQPNYdEVi6wUYIBFFO8vCw==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-web-service-worker-1.0.30.tar.gz",
+      "integrity": "sha512-SOoJm7NEiyvUSQVYbRTq0Z+JdmBoeDzQwqJzfCx8AU+5GbOBP+gADOThobiEOD0MI0Dxphz3lfiessrJflLnfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "1.0.28"
+        "@php-wasm/scopes": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-scopes-1.0.30.tar.gz"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.148",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.148.tgz",
-      "integrity": "sha512-JL+2cfkY9ODQeE06hOxSFNkafjNk4JRBgY837kpoq1GHDttq2U3BA9IzKOWxS4DLjKoymGB4i9uBrlCkjUl1yg==",
+      "version": "8.10.149",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
+      "integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
       "license": "MIT"
     },
     "node_modules/@types/btoa-lite": {
@@ -742,20 +745,22 @@
       "license": "MIT"
     },
     "node_modules/@wp-playground/blueprints": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-1.0.28.tgz",
-      "integrity": "sha512-Y8BQJdyIs4fbeerGrVdMxiyq51RF+N4NQ9FhDvVVe8luKCdn3L1lP78sO9OAowUjMxQYnjLgiCz527ZyIYwoZQ==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-blueprints-1.0.30.tar.gz",
+      "integrity": "sha512-o4h7Hc1tP7mTo9n9ZZUMc4yWeN55t0PBvbTA/7IjsGRT0ZpZ+YD6kHXWZgLRTe7bwLHC4wZ3yu43ucTlg+lNDw==",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node": "1.0.28",
-        "@php-wasm/node-polyfills": "1.0.28",
-        "@php-wasm/progress": "1.0.28",
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
-        "@php-wasm/web": "1.0.28",
-        "@wp-playground/common": "1.0.28",
-        "@wp-playground/storage": "1.0.28",
-        "@wp-playground/wordpress": "1.0.28",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-1.0.30.tar.gz",
+        "@php-wasm/node-polyfills": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-polyfills-1.0.30.tar.gz",
+        "@php-wasm/progress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-progress-1.0.30.tar.gz",
+        "@php-wasm/stream-compression": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-stream-compression-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
+        "@php-wasm/web": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-web-1.0.30.tar.gz",
+        "@wp-playground/common": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-common-1.0.30.tar.gz",
+        "@wp-playground/storage": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-storage-1.0.30.tar.gz",
+        "@wp-playground/wordpress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-wordpress-1.0.30.tar.gz",
+        "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
         "buffer": "6.0.3",
@@ -763,8 +768,6 @@
         "comlink": "^4.4.1",
         "crc-32": "1.2.2",
         "diff3": "0.0.4",
-        "events": "3.3.0",
-        "express": "4.19.2",
         "ignore": "5.2.4",
         "ini": "4.1.2",
         "minimisted": "2.0.1",
@@ -774,28 +777,28 @@
         "readable-stream": "3.6.2",
         "sha.js": "2.4.11",
         "simple-get": "4.0.1",
-        "wasm-feature-detect": "1.8.0",
-        "ws": "8.18.0",
-        "yargs": "17.7.2"
+        "wasm-feature-detect": "1.8.0"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@wp-playground/cli": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-1.0.28.tgz",
-      "integrity": "sha512-SZaXsaQ+x/JkEIlxW/0h2CkmSyBfIDzc/Y+SRnV6L69KuCsyzwnIrSZVR85BUrfGNfNbvf0yXduo5EdMpZ10tg==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-cli-1.0.30.tar.gz",
+      "integrity": "sha512-AkeV/FjF2XZT8ilAej23jK5SKjbctlyJdHtnHBeuX/DDSW/YtjVv36t+SKQ+bknLMyhqIJTd4u4jy+Z3ruSN9A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node": "1.0.28",
-        "@php-wasm/progress": "1.0.28",
-        "@php-wasm/universal": "1.0.28",
-        "@wp-playground/blueprints": "1.0.28",
-        "@wp-playground/common": "1.0.28",
-        "@wp-playground/wordpress": "1.0.28",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-1.0.30.tar.gz",
+        "@php-wasm/progress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-progress-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@wp-playground/blueprints": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-blueprints-1.0.30.tar.gz",
+        "@wp-playground/common": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-common-1.0.30.tar.gz",
+        "@wp-playground/storage": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-storage-1.0.30.tar.gz",
+        "@wp-playground/wordpress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-wordpress-1.0.30.tar.gz",
+        "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
         "buffer": "6.0.3",
@@ -804,7 +807,7 @@
         "crc-32": "1.2.2",
         "diff3": "0.0.4",
         "events": "3.3.0",
-        "express": "4.19.2",
+        "express": "4.21.2",
         "fs-extra": "11.1.1",
         "ignore": "5.2.4",
         "ini": "4.1.2",
@@ -824,30 +827,32 @@
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-1.0.28.tgz",
-      "integrity": "sha512-Qz4kFT4m6Z60Iz7BLe1+Y8DzJ2v0v50wGSGmOJ0t4+G6vkkbuA6JbV9+DDi8EhubZDg2I9CJv6qZGJbAyzQRzA==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-common-1.0.30.tar.gz",
+      "integrity": "sha512-NZKi5Hri+d7DjKZ65IZ0HwH69u9o41YQUUEkS0E9wPHb+U58F2//N2M2poIRvQDVwo+kyvbfGEuFInC/sqzLZw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
         "comlink": "^4.4.1",
         "ini": "4.1.2"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-1.0.28.tgz",
-      "integrity": "sha512-mkx05mgkOUfSEEHTpyG0WIPXAgsk+5CBkoe+mU1emxF9NTBHW3IglrB03k8rFopjNJC3CUDsouivQ0SIVBYX/Q==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-storage-1.0.30.tar.gz",
+      "integrity": "sha512-H2JAA/fUDSn0Gsxwj7TqrXPMe7Dy20B8rqmRprhEGzYtHLn/yc3xnHdt3qw9yCQj3H5Hfqqqc5nFCcsQESlb8Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
-        "@php-wasm/web": "1.0.28",
+        "@php-wasm/stream-compression": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-stream-compression-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
+        "@php-wasm/web": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-web-1.0.30.tar.gz",
+        "@zip.js/zip.js": "2.7.57",
         "async-lock": "^1.4.1",
         "buffer": "6.0.3",
         "clean-git-ref": "^2.0.1",
@@ -855,7 +860,7 @@
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
         "events": "3.3.0",
-        "express": "4.19.2",
+        "express": "4.21.2",
         "ignore": "^5.1.4",
         "ini": "4.1.2",
         "minimisted": "^2.0.0",
@@ -886,27 +891,38 @@
       }
     },
     "node_modules/@wp-playground/wordpress": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-1.0.28.tgz",
-      "integrity": "sha512-uxYVRtN3jL1aQ24JJpLjx1R94XpVFVjqXihlGT791LL7LQITfo72f68zj+eqiJtVBCYUNenQfwLy7hSs5kcKLA==",
+      "version": "1.0.30",
+      "resolved": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-wordpress-1.0.30.tar.gz",
+      "integrity": "sha512-JnwYnBZyiWCE7pszji+LNPVaznfEMTy9J1q7gJ36eo6QZ8y7bH+cV3FZegIklDJgQetxpWr4u9hP9sAWahjULA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.0.28",
-        "@php-wasm/node": "1.0.28",
-        "@php-wasm/universal": "1.0.28",
-        "@php-wasm/util": "1.0.28",
-        "@wp-playground/common": "1.0.28",
+        "@php-wasm/logger": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-logger-1.0.30.tar.gz",
+        "@php-wasm/node": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-node-1.0.30.tar.gz",
+        "@php-wasm/universal": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-universal-1.0.30.tar.gz",
+        "@php-wasm/util": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@php-wasm-util-1.0.30.tar.gz",
+        "@wp-playground/common": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-common-1.0.30.tar.gz",
         "comlink": "^4.4.1",
         "events": "3.3.0",
-        "express": "4.19.2",
+        "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"
       },
       "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
+        "node": ">=20.9.0",
+        "npm": ">=10.1.0"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.57",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+      "integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
       }
     },
     "node_modules/accepts": {
@@ -1014,9 +1030,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -1027,7 +1043,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -1192,9 +1208,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1309,9 +1325,9 @@
       "license": "MIT"
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1381,37 +1397,37 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -1420,6 +1436,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1429,13 +1449,13 @@
       "license": "MIT"
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -1812,10 +1832,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "license": "MIT"
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -1974,9 +1997,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/pify": {
@@ -2014,12 +2037,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -2123,9 +2146,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -2146,6 +2169,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2153,15 +2185,15 @@
       "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@types/yargs": "^17.0.33",
-    "@wp-playground/cli": "^1.0.28",
+    "@wp-playground/cli": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.30/@wp-playground-cli-1.0.30.tar.gz",
     "yargs": "^17.7.2"
   },
   "volta": {

--- a/scripts/lib/blueprints/generate-blueprint.sh
+++ b/scripts/lib/blueprints/generate-blueprint.sh
@@ -132,4 +132,17 @@ elif [ "$item_type" = "themes" ]; then
     jq -s '.[0] * .[1]' <(echo "$blueprint") <(echo "$theme_steps") > "$blueprint_path"
 fi
 
+# Disable WP auto-updates and WP cron.
+jq --arg blueprint "$(cat "$blueprint_path")" '
+    . = ($blueprint | fromjson) |
+    .steps = ([{
+        "step": "defineWpConfigConsts",
+        "consts": {
+            "WP_AUTO_UPDATE_CORE": false,
+            "DISABLE_WP_CRON": true
+        }
+    }] + .steps)
+' <<< '{}' > "$blueprint_path"
+
+
 echo "$blueprint_path"

--- a/scripts/lib/playground-tests/ast-sqlite-boot.sh
+++ b/scripts/lib/playground-tests/ast-sqlite-boot.sh
@@ -63,9 +63,6 @@ EOL
 asl_blueprint_path=$(mktemp).json
 jq -s '.[0] as $new | .[1] | .steps = ($new + .steps)' "$new_steps_file" "$blueprint_path" > "$asl_blueprint_path"
 
-# The new SQLite driver doesn't support PHP 7.2 or 7.3, so we need to update the PHP version to 7.4
-jq '.preferredVersions.php = (if .preferredVersions.php == "7.2" or .preferredVersions.php == "7.3" then "7.4" else .preferredVersions.php end)' "$asl_blueprint_path" > "${asl_blueprint_path}.tmp" && mv "${asl_blueprint_path}.tmp" "$asl_blueprint_path"
-
 wordpress_args=""
 if [ -n "$wordpress_path" ]; then
   wordpress_args=" --skipWordPressSetup --mountBeforeInstall $wordpress_path:/wordpress"

--- a/scripts/lib/playground-tests/ast-sqlite-boot.sh
+++ b/scripts/lib/playground-tests/ast-sqlite-boot.sh
@@ -60,7 +60,7 @@ cat > "$new_steps_file" << 'EOL'
 EOL
 
 
-asl_blueprint_path=$(mktemp)
+asl_blueprint_path=$(mktemp).json
 jq -s '.[0] as $new | .[1] | .steps = ($new + .steps)' "$new_steps_file" "$blueprint_path" > "$asl_blueprint_path"
 
 # The new SQLite driver doesn't support PHP 7.2 or 7.3, so we need to update the PHP version to 7.4

--- a/scripts/unit-tests/test-run-tests.sh
+++ b/scripts/unit-tests/test-run-tests.sh
@@ -20,7 +20,7 @@ run_test "Test a successful plugin run"\
 ✓ 0gravatar passed jspi-boot"
 
 run_test "Test a failed plugin run"\
-    "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/g/gl-import-external-images --wordpress ./temp/wordpress" \
-    "✗ gl-import-external-images failed ast-sqlite-boot
-✗ gl-import-external-images failed asyncify-boot
-✗ gl-import-external-images failed jspi-boot"
+    "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/1/1qlick --wordpress ./temp/wordpress" \
+    "✗ 1qlick failed ast-sqlite-boot
+✗ 1qlick failed asyncify-boot
+✗ 1qlick failed jspi-boot"


### PR DESCRIPTION
Some plugin/theme tests were failing because of our testing setup.

This PR:
- Disables WP cron. This was causing `Uncaught Error: Class 'WpOrg\Requests\Response' not found in /wordpress/wp-includes/Requests/src/Requests.php:724`. I'm not exactly sure why, we can investigate it further.
- Disables WP core auto-updates. Probably not so important, but maybe it could affect some runs at the time of WP core updates. It's safer to disable them.
- Update the Playground CLI.
- Enable PHP < 7.4 for AST tests (this is enabled by the Playground CLI update).