### PR TITLE
User runCLI and unit tests to test plugins and themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 temp
 .DS_Store
+.claude

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@types/yargs": "^17.0.33",
         "@wp-playground/cli": "^3.0.15",
-        "@wp-playground/wordpress-builds": "^0.9.19",
+        "wasm-feature-detect": "^1.8.0",
         "yargs": "^17.7.2"
       },
       "devDependencies": {
@@ -1878,16 +1878,6 @@
       },
       "optionalDependencies": {
         "fs-ext": "2.1.1"
-      }
-    },
-    "node_modules/@wp-playground/wordpress-builds": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress-builds/-/wordpress-builds-0.9.19.tgz",
-      "integrity": "sha512-dlqvh/MJDpE5W68vgPPKUjpip6zMuBh59L3D18ZX+pdwurC4q4ydrTww/3sTMV69BBcoH6kF93YtAtujNC5Mpw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.18.0",
-        "npm": ">=8.11.0"
       }
     },
     "node_modules/@zip.js/zip.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,465 @@
     "": {
       "dependencies": {
         "@types/yargs": "^17.0.33",
-        "@wp-playground/cli": "^1.1.0",
+        "@wp-playground/cli": "^3.0.15",
+        "@wp-playground/wordpress-builds": "^0.9.19",
         "yargs": "^17.7.2"
+      },
+      "devDependencies": {
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": "23.11.0"
       }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
+      "integrity": "sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.11.tgz",
+      "integrity": "sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.11.tgz",
+      "integrity": "sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.11.tgz",
+      "integrity": "sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.11.tgz",
+      "integrity": "sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.11.tgz",
+      "integrity": "sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.11.tgz",
+      "integrity": "sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.11.tgz",
+      "integrity": "sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.11.tgz",
+      "integrity": "sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.11.tgz",
+      "integrity": "sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.11.tgz",
+      "integrity": "sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.11.tgz",
+      "integrity": "sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.11.tgz",
+      "integrity": "sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.11.tgz",
+      "integrity": "sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.11.tgz",
+      "integrity": "sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.11.tgz",
+      "integrity": "sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.11.tgz",
+      "integrity": "sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.11.tgz",
+      "integrity": "sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.11.tgz",
+      "integrity": "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.11.tgz",
+      "integrity": "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@octokit/app": {
       "version": "14.1.0",
@@ -32,9 +485,9 @@
       }
     },
     "node_modules/@octokit/auth-app": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.3.tgz",
-      "integrity": "sha512-dcaiteA6Y/beAlDLZOPNReN3FGHu+pARD6OHfh3T9f3EO09++ec+5wt3KtGGSSs2Mp5tI8fQwdMOEnrzBLfgUA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+      "integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-oauth-app": "^7.1.0",
@@ -184,9 +637,9 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
-      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
@@ -497,9 +950,9 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.1.tgz",
-      "integrity": "sha512-BVwtWE3rRXB9IugmQTfKspqjNa8q+ab73ddkV9k1Zok3XbuOxJUi4lTYk5zBZDhfWb/Y2H+RO9Iggm25gsqeow==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+      "integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
       "license": "MIT",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
@@ -527,16 +980,15 @@
       "license": "MIT"
     },
     "node_modules/@php-wasm/fs-journal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-1.1.0.tgz",
-      "integrity": "sha512-ZbTL3C1z4wT2Phkh19fPZKX8YBYxc1oWxe4zezP/aZjf1XlCGDXYehBV0RiY9EdkrZs96wzAVDBrllUL1iV+LA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.0.15.tgz",
+      "integrity": "sha512-l0iL3E66pla+yJlWHKGO8NaYact6cuzztEXqYC/St5C1rejXWfXCS2FOAui5JuDyRiX3jn7X35ukkwiAOxZfvw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "comlink": "^4.4.1",
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
         "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
@@ -546,34 +998,38 @@
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/logger": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-1.1.0.tgz",
-      "integrity": "sha512-ZJRu0hSMQRnrbG0KNIBQoKtg/Jn2Rb4CcgyXCRKfmOrFaz3B1ij9cxasujtFeh4uGOZEcKZXObKF7fAi2ZDJLg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.0.15.tgz",
+      "integrity": "sha512-zEOjowjTZpPob3tAajvsXoD2WXhk5PszXdmc8QkOKtPWObSHYqQh9u2631KkVFkjiVHfLbDLybuzREOPVwutpg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "1.1.0"
+        "@php-wasm/node-polyfills": "3.0.15"
       },
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-1.1.0.tgz",
-      "integrity": "sha512-fEG4T+vCv1R5DOlp+VVR8ElQRGqwoqwHvC5YgpnAo1wYfitgPfGnerSKUOTg0ogyOAE0KuFhXSX7QRoM37DsVQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.0.15.tgz",
+      "integrity": "sha512-hwZXE2SOpcEwYLeVvMqUqdoTC3A8Y8VJMgM2+yL5P/R6o1NtV8WlGBeNJYaaZ/+XOXedc00Z6J/eNxGK0xcO9g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node-polyfills": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "@wp-playground/common": "1.1.0",
-        "@wp-playground/wordpress": "1.1.0",
-        "comlink": "^4.4.1",
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node-polyfills": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
+        "@wp-playground/common": "3.0.15",
         "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
@@ -583,88 +1039,107 @@
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/node-polyfills": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-1.1.0.tgz",
-      "integrity": "sha512-SoYGhyi6XGNsaGFyel2C53PzQ8z6Q3JSV+6q3or9LOjfMn5lTQyrRQUlKbIJkjmlD+EQrihRevLXRCtR44vItQ==",
-      "license": "GPL-2.0-or-later"
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.0.15.tgz",
+      "integrity": "sha512-rFrv4UCFlheUwkj8yjuactj9ouQZ3xKq1FyMIjC5Xsh4ervAKZj8OZPS/kYTJfybK+6c1mLQ8sM8PtITAaeYDQ==",
+      "license": "GPL-2.0-or-later",
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
+      }
     },
     "node_modules/@php-wasm/progress": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-1.1.0.tgz",
-      "integrity": "sha512-et/i/+ZmNpguYRt1ThOTckAP3evSFvMfwIeWukfEq+rMH8bqRcExh7qdxAt1SNeSixM854qCDxfO4XGP6yIyXA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.0.15.tgz",
+      "integrity": "sha512-044zmdrPf8ep48em3uxO8lmzuQLmIKttqaqfJJ4Zij2AMCCGm8WUcj1SoZqJqkave19y7auQPlpJePiDp9Gr0g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node-polyfills": "1.1.0"
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node-polyfills": "3.0.15"
       },
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/scopes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-1.1.0.tgz",
-      "integrity": "sha512-/e/tG7paeRwZB6n+4YctqKr65t4wlE0NfjyS0qV5vg43ouPRMPzLfiEfMO/lsvDCBsesCkinR2YnaAOhZzqW+w==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.0.15.tgz",
+      "integrity": "sha512-XexxMpt0tE1oB70mDcuYfwX/Fkb5Anbu0CQ8m0v3EXvQn0tkifvpP6Ff1Ei6fkp9vm7s4rMaWngBMVGBa0iZpA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/stream-compression": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-1.1.0.tgz",
-      "integrity": "sha512-Ew8c/UNygFT2WlZ9OiOjCbkIPm3pK09MsqmKBVfJZAka6m0Ez9X1CXGvqnkVnn8bp0jsWvMfm5COflBG5qRZhg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.0.15.tgz",
+      "integrity": "sha512-a/AVTZWTW7ilM21fTgm8jHsGVKIy15wAV6o4J8VRtqGF5bTI7XqiEOMBEZHCm+uyluHjYs23wrifXuu1RW5grw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/node-polyfills": "1.1.0",
-        "@php-wasm/util": "1.1.0"
+        "@php-wasm/node-polyfills": "3.0.15",
+        "@php-wasm/util": "3.0.15"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/universal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-1.1.0.tgz",
-      "integrity": "sha512-63dSqA89Mj8KxmRtoOtJuRSnOQPYhReDoQHd2dcCEoUI4CRkkiL9Yp3FwdTQeyUjPyVXVOrdRgisxWuS3DMwZQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.0.15.tgz",
+      "integrity": "sha512-9a99cZxCtJJu/s1L4+2n1DGqA2vWvd1LgwlillSrWicfDSvqplTJOBu1iWWv3GFTKO0KsUK8CuvgYgTm1RiCww==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node-polyfills": "1.1.0",
-        "@php-wasm/progress": "1.1.0",
-        "@php-wasm/stream-compression": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "comlink": "^4.4.1",
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node-polyfills": "3.0.15",
+        "@php-wasm/progress": "3.0.15",
+        "@php-wasm/stream-compression": "3.0.15",
+        "@php-wasm/util": "3.0.15",
         "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/util": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-1.1.0.tgz",
-      "integrity": "sha512-TooE2XMc+fThhbSrNKu5ly0AGNLFmhRsvfTYNYz8cWV/Do44VgtHZOHsvrM0BFYp3Yp427Kp9DINV9eAB8QbWw==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.0.15.tgz",
+      "integrity": "sha512-Y/TDDgcWmnrWv5JOC4QJsBiqlBV/5ORfXL3HXZ+JHJuscRboNRQA7yyRMUWdUmfV0dIuAOyHd8wcyd3ryH1r+Q==",
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/web": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-1.1.0.tgz",
-      "integrity": "sha512-EFF7GeXyIpRg59HO3cGMhs2YLCttQjYFkxrWm9/VEmadLrP5XEkEq4wuc5SywYbKacSiaE5/2ZqLX3aOmjY7ZA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.0.15.tgz",
+      "integrity": "sha512-U5aItYqsNFzfXeiDP24yI9Ie4em20wkNYo1PXJ9fdihRFQ7j3vPCsN2EfF1P6phzKh/FZBdjczXPlbQ6mhlxkw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/fs-journal": "1.1.0",
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "@php-wasm/web-service-worker": "1.1.0",
-        "comlink": "^4.4.1",
+        "@php-wasm/fs-journal": "3.0.15",
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
+        "@php-wasm/web-service-worker": "3.0.15",
         "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
@@ -674,25 +1149,367 @@
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@php-wasm/web-service-worker": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-1.1.0.tgz",
-      "integrity": "sha512-oKaWmdCNIp42B3I0luLky2YAFtXcjXE+e6+V5Ca6BATbYsjuSlr0WIAwDWbODIwwD4Lz/Ha5zljsaBSdra3jzQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.0.15.tgz",
+      "integrity": "sha512-ABWHynnu5hn/qPz//r+ebEoyHPjJI1GRL7VYijnltRJKW5EPocne0p/lL2zYBspfXVCMEBFYzV4eFLQ90+KL3g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/scopes": "1.1.0"
+        "@php-wasm/scopes": "3.0.15"
       },
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
+    "node_modules/@php-wasm/xdebug-bridge": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.0.15.tgz",
+      "integrity": "sha512-NTFBmAU2EVaB7KPtYxYUsYO6l+wOtN6zARTeVjYYT2S/W2b312IRva1cDTwjKEbz8aS6aczIP7EzYvUboXBCRw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@wp-playground/common": "3.0.15",
+        "express": "4.21.2",
+        "ini": "4.1.2",
+        "wasm-feature-detect": "1.8.0",
+        "ws": "8.18.1",
+        "xml2js": "0.6.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "xdebug-bridge": "xdebug-bridge.js"
+      },
+      "engines": {
+        "node": ">=20.18.3",
+        "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.149",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
-      "integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
+      "version": "8.10.157",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.157.tgz",
+      "integrity": "sha512-ofjcRCO1N7tMZDSO11u5bFHPDfUFD3Q9YK9g4S4w8UDKuG3CNlw2lNK1sd3Itdo7JORygZmG4h9ZykS8dlXvMA==",
       "license": "MIT"
     },
     "node_modules/@types/btoa-lite": {
@@ -701,10 +1518,35 @@
       "integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
-      "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*",
@@ -718,12 +1560,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "24.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
+      "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/yargs": {
@@ -741,27 +1583,141 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
-    "node_modules/@wp-playground/blueprints": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-1.1.0.tgz",
-      "integrity": "sha512-vXswg0QSiMZIYgkyOrO3JlgFr+vTiM8VtizJq0D/iHPV4sM/fSS4aETTlmDCW8mf4KjLVlqiY100fdBHxkuF+Q==",
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node": "1.1.0",
-        "@php-wasm/node-polyfills": "1.1.0",
-        "@php-wasm/progress": "1.1.0",
-        "@php-wasm/stream-compression": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "@php-wasm/web": "1.1.0",
-        "@wp-playground/common": "1.1.0",
-        "@wp-playground/storage": "1.1.0",
-        "@wp-playground/wordpress": "1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wp-playground/blueprints": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.0.15.tgz",
+      "integrity": "sha512-RJl6NPxenhY2kttxdQ23TYEx4PxNhNmMXsWZDM4W1//wWX7UPQtlOx/XqDdcCXg497blj9Yz/yfBguVc/Yiy4A==",
+      "dependencies": {
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node": "3.0.15",
+        "@php-wasm/node-polyfills": "3.0.15",
+        "@php-wasm/progress": "3.0.15",
+        "@php-wasm/stream-compression": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
+        "@php-wasm/web": "3.0.15",
+        "@wp-playground/common": "3.0.15",
+        "@wp-playground/storage": "3.0.15",
+        "@wp-playground/wordpress": "3.0.15",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
-        "comlink": "^4.4.1",
         "crc-32": "1.2.2",
         "diff3": "0.0.4",
         "express": "4.21.2",
@@ -772,7 +1728,7 @@
         "pako": "1.0.10",
         "pify": "2.3.0",
         "readable-stream": "3.6.2",
-        "sha.js": "2.4.11",
+        "sha.js": "2.4.12",
         "simple-get": "4.0.1",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.1",
@@ -781,27 +1737,31 @@
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@wp-playground/cli": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-1.1.0.tgz",
-      "integrity": "sha512-U5pEWUFEgIczQF93Gcj4mMvRoe1DNA0EtsRcgbz+LwvKbWVi8BDLL8odWsyo+JUuA+/i2k2XCo4KnB0QD2jJxg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.0.15.tgz",
+      "integrity": "sha512-KuFyUpLvHoNJDpd4Wm9mExl9N490M2OTepUrbO81dJg1PjhrTQxULs7Fc8wwIHR4Oc07qLIO3gr8AL+D4M0p4Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node": "1.1.0",
-        "@php-wasm/progress": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@wp-playground/blueprints": "1.1.0",
-        "@wp-playground/common": "1.1.0",
-        "@wp-playground/storage": "1.1.0",
-        "@wp-playground/wordpress": "1.1.0",
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node": "3.0.15",
+        "@php-wasm/progress": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
+        "@php-wasm/xdebug-bridge": "3.0.15",
+        "@wp-playground/blueprints": "3.0.15",
+        "@wp-playground/common": "3.0.15",
+        "@wp-playground/storage": "3.0.15",
+        "@wp-playground/wordpress": "3.0.15",
         "@zip.js/zip.js": "2.7.57",
         "ajv": "8.12.0",
         "async-lock": "1.4.1",
         "clean-git-ref": "2.0.1",
-        "comlink": "^4.4.1",
         "crc-32": "1.2.2",
         "diff3": "0.0.4",
         "express": "4.21.2",
@@ -812,47 +1772,54 @@
         "octokit": "3.1.2",
         "pako": "1.0.10",
         "pify": "2.3.0",
+        "ps-man": "1.1.8",
         "readable-stream": "3.6.2",
-        "sha.js": "2.4.11",
+        "sha.js": "2.4.12",
         "simple-get": "4.0.1",
+        "tmp-promise": "3.0.3",
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.1",
+        "xml2js": "0.6.2",
         "yargs": "17.7.2"
       },
       "bin": {
-        "cli": "wp-playground.js"
+        "wp-playground-cli": "wp-playground.js"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@wp-playground/common": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-1.1.0.tgz",
-      "integrity": "sha512-1BlFsvWVf7MJ3Y3a3VuUZLdNpFZzZI2iVrJlNXbThvz9wiZ6wKxhumqGeTvO/j5QroBYyy7bdqPz5Qrghv84CA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.0.15.tgz",
+      "integrity": "sha512-JAgD+fbKorAA5AJ8Xeh2F5din16nw1DfTT98A6O+Nbb8phlCbpyX3+aA7R8U168dFHO2kdNAZCJvMrqrj7iC6A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "comlink": "^4.4.1",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
         "ini": "4.1.2"
       },
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@wp-playground/storage": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-1.1.0.tgz",
-      "integrity": "sha512-RQzmEN/Ys2Qg5VsISGcSDXSdfy9GLmPoJK4a/RUPxgA6meJxewwEH+l9eScn0/HaGE9kmiODt4WbFaT/KadmfA==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.0.15.tgz",
+      "integrity": "sha512-f8q/ciEcZo/Gqs3JQ3uUvGjZ35Yi5DUH6M7vpFxcEYQ0B/S53ttS8+LiLZLPeRfYs5pMTkq5UH4M/a9UuX3vfA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/stream-compression": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "@php-wasm/web": "1.1.0",
+        "@php-wasm/stream-compression": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
+        "@php-wasm/web": "3.0.15",
         "@zip.js/zip.js": "2.7.57",
         "async-lock": "^1.4.1",
         "clean-git-ref": "^2.0.1",
-        "comlink": "^4.4.1",
         "crc-32": "^1.2.0",
         "diff3": "0.0.3",
         "express": "4.21.2",
@@ -868,6 +1835,9 @@
         "wasm-feature-detect": "1.8.0",
         "ws": "8.18.1",
         "yargs": "17.7.2"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
       }
     },
     "node_modules/@wp-playground/storage/node_modules/diff3": {
@@ -886,17 +1856,16 @@
       }
     },
     "node_modules/@wp-playground/wordpress": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-1.1.0.tgz",
-      "integrity": "sha512-1fLN0wJcJrcl3W5y/ZjV8bjo7d5fXA4QDV/vQsi/hKmBv1yPwdEriv4Y982luXqnvfEsJG4z7wPO4CBSqMCOsg==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.0.15.tgz",
+      "integrity": "sha512-R2SVSY96iuyTJKmtz6O4kMKAuclhjZGBZRdPhPT+elIjhLEcsSMz0epZWrzDRxomHD7O1COj1OVF7c8dfmNg+A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@php-wasm/logger": "1.1.0",
-        "@php-wasm/node": "1.1.0",
-        "@php-wasm/universal": "1.1.0",
-        "@php-wasm/util": "1.1.0",
-        "@wp-playground/common": "1.1.0",
-        "comlink": "^4.4.1",
+        "@php-wasm/logger": "3.0.15",
+        "@php-wasm/node": "3.0.15",
+        "@php-wasm/universal": "3.0.15",
+        "@php-wasm/util": "3.0.15",
+        "@wp-playground/common": "3.0.15",
         "express": "4.21.2",
         "ini": "4.1.2",
         "wasm-feature-detect": "1.8.0",
@@ -906,6 +1875,19 @@
       "engines": {
         "node": ">=20.18.3",
         "npm": ">=10.1.0"
+      },
+      "optionalDependencies": {
+        "fs-ext": "2.1.1"
+      }
+    },
+    "node_modules/@wp-playground/wordpress-builds": {
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/@wp-playground/wordpress-builds/-/wordpress-builds-0.9.19.tgz",
+      "integrity": "sha512-dlqvh/MJDpE5W68vgPPKUjpip6zMuBh59L3D18ZX+pdwurC4q4ydrTww/3sTMV69BBcoH6kF93YtAtujNC5Mpw==",
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.18.0",
+        "npm": ">=8.11.0"
       }
     },
     "node_modules/@zip.js/zip.js": {
@@ -991,11 +1973,36 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-lock": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
@@ -1054,6 +2061,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1081,6 +2116,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clean-git-ref": {
@@ -1129,12 +2191,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/comlink": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
-      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
-      "license": "Apache-2.0"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1206,6 +2262,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -1301,6 +2384,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1311,6 +2401,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz",
+      "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.11",
+        "@esbuild/android-arm": "0.25.11",
+        "@esbuild/android-arm64": "0.25.11",
+        "@esbuild/android-x64": "0.25.11",
+        "@esbuild/darwin-arm64": "0.25.11",
+        "@esbuild/darwin-x64": "0.25.11",
+        "@esbuild/freebsd-arm64": "0.25.11",
+        "@esbuild/freebsd-x64": "0.25.11",
+        "@esbuild/linux-arm": "0.25.11",
+        "@esbuild/linux-arm64": "0.25.11",
+        "@esbuild/linux-ia32": "0.25.11",
+        "@esbuild/linux-loong64": "0.25.11",
+        "@esbuild/linux-mips64el": "0.25.11",
+        "@esbuild/linux-ppc64": "0.25.11",
+        "@esbuild/linux-riscv64": "0.25.11",
+        "@esbuild/linux-s390x": "0.25.11",
+        "@esbuild/linux-x64": "0.25.11",
+        "@esbuild/netbsd-arm64": "0.25.11",
+        "@esbuild/netbsd-x64": "0.25.11",
+        "@esbuild/openbsd-arm64": "0.25.11",
+        "@esbuild/openbsd-x64": "0.25.11",
+        "@esbuild/openharmony-arm64": "0.25.11",
+        "@esbuild/sunos-x64": "0.25.11",
+        "@esbuild/win32-arm64": "0.25.11",
+        "@esbuild/win32-ia32": "0.25.11",
+        "@esbuild/win32-x64": "0.25.11"
       }
     },
     "node_modules/escalade": {
@@ -1328,6 +2460,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1335,6 +2477,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1389,6 +2541,24 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -1405,6 +2575,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/forwarded": {
@@ -1425,6 +2610,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-ext": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fs-ext/-/fs-ext-2.1.1.tgz",
+      "integrity": "sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.21.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
@@ -1437,6 +2635,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1512,11 +2725,38 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1606,6 +2846,18 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1614,6 +2866,34 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1724,6 +3004,13 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "name": "@wolfy1339/lru-cache",
       "version": "11.0.2-patch.1",
@@ -1732,6 +3019,16 @@
       "license": "ISC",
       "engines": {
         "node": "18 >=18.20 || 20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1839,6 +3136,32 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1923,6 +3246,43 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1930,6 +3290,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -1944,6 +3342,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/ps-man": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
+      "integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2025,6 +3429,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2051,10 +3497,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2117,6 +3569,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2124,16 +3593,23 @@
       "license": "ISC"
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -2208,6 +3684,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -2253,6 +3736,23 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2261,6 +3761,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2297,6 +3804,112 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2319,10 +3932,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {
@@ -2392,11 +4019,270 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
+      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wasm-feature-detect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
       "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -2440,6 +4326,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,18 @@
     "node": "23.11.0"
   },
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:batch": "node --experimental-strip-types --disable-warning=ExperimentalWarning src/test-batch.ts",
     "download:plugins": "node --experimental-strip-types --disable-warning=ExperimentalWarning src/download-plugins.ts"
   },
   "dependencies": {
     "@types/yargs": "^17.0.33",
-    "@wp-playground/cli": "^1.1.0",
+    "@wp-playground/cli": "^3.0.15",
     "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   },
   "volta": {
     "node": "23.11.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@types/yargs": "^17.0.33",
     "@wp-playground/cli": "^3.0.15",
+    "wasm-feature-detect": "^1.8.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/scripts/unit-tests/test-run-tests.sh
+++ b/scripts/unit-tests/test-run-tests.sh
@@ -21,6 +21,6 @@ run_test "Test a successful plugin run"\
 
 run_test "Test a failed plugin run"\
     "./scripts/run-tests.sh --plugin $PLAYGROUND_TESTER_DATA_PATH/logs/plugins/1/1qlick --wordpress ./temp/wordpress" \
-    "✗ 1qlick failed ast-sqlite-boot
-✗ 1qlick failed asyncify-boot
-✗ 1qlick failed jspi-boot"
+    "✓ 1qlick passed ast-sqlite-boot
+✓ 1qlick passed asyncify-boot
+✓ 1qlick passed jspi-boot"

--- a/src/lib/log-parser.ts
+++ b/src/lib/log-parser.ts
@@ -1,0 +1,306 @@
+/**
+ * Log parser for Playground Tester error logs and test results.
+ * Parses error.log files and results.json files to generate error.json reports.
+ */
+import { readFileSync, existsSync } from 'fs';
+
+export interface ErrorEntry {
+    message: string;
+    level: 'FATAL' | 'WARNING' | 'PARSE' | 'NOTICE' | 'DEPRECATED' | 'STRICT' | 'RECOVERABLE_FATAL' | 'INFO';
+    type: 'PHP' | 'SQL' | 'PLAYGROUND' | 'OTHER';
+    test: string;
+    plugin?: string;
+    theme?: string;
+    details: string;
+    log: string;
+}
+
+export interface TestResultsMeta {
+    error?: {
+        message: string;
+        stack: string;
+    };
+}
+
+export interface AssertionResult {
+    ancestorTitles: string[];
+    fullName: string;
+    status: string;
+    title: string;
+    failureMessages?: string[];
+    meta?: TestResultsMeta;
+}
+
+export interface TestResult {
+    assertionResults: AssertionResult[];
+    status: string;
+    name: string;
+}
+
+export interface TestResults {
+    success: boolean;
+    testResults: TestResult[];
+}
+
+/**
+ * Preprocesses error log content by removing CLI output artifacts
+ */
+function prepareLogContent(content: string): string {
+    let processed = content;
+
+    // Remove "Node.js v..." lines
+    processed = processed.replace(/^Node\.js v.*/gm, '');
+
+    // Remove "Error: " prefix before PHP error timestamps
+    processed = processed.replace(
+        /^Error: (\[\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} UTC\])/gm,
+        '$1'
+    );
+
+    return processed;
+}
+
+/**
+ * Parses an error.log file and extracts structured error entries
+ */
+export function parseErrorLog(
+    logPath: string,
+    testName: string,
+    itemType: 'plugin' | 'theme',
+    itemName: string,
+    logFilePath: string
+): ErrorEntry[] {
+    if (!existsSync(logPath)) {
+        return [];
+    }
+
+    const content = readFileSync(logPath, 'utf-8');
+    const prepared = prepareLogContent(content);
+
+    // Check if file is empty or contains only whitespace
+    if (!prepared.trim()) {
+        return [];
+    }
+
+    const lines = prepared.split('\n');
+    const errors: ErrorEntry[] = [];
+    let currentError: ErrorEntry | null = null;
+
+    for (const line of lines) {
+        // Check if this line starts a new error
+        const timestampMatch = line.match(/^\[(\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} UTC)\]/);
+        const playgroundMatch = line.match(/^file:\/\/\/.*\.js:\d+/);
+
+        if (timestampMatch) {
+            // Save previous error if exists
+            if (currentError && currentError.details) {
+                errors.push(currentError);
+            }
+
+            // Determine error level and type
+            let level: ErrorEntry['level'] = 'INFO';
+            let type: ErrorEntry['type'] = 'OTHER';
+
+            if (line.includes('PHP Fatal error')) {
+                level = 'FATAL';
+                type = 'PHP';
+            } else if (line.includes('PHP Warning')) {
+                level = 'WARNING';
+                type = 'PHP';
+            } else if (line.includes('PHP Parse error')) {
+                level = 'PARSE';
+                type = 'PHP';
+            } else if (line.includes('PHP Notice')) {
+                level = 'NOTICE';
+                type = 'PHP';
+            } else if (line.includes('PHP Deprecated')) {
+                level = 'DEPRECATED';
+                type = 'PHP';
+            } else if (line.includes('PHP Strict Standards')) {
+                level = 'STRICT';
+                type = 'PHP';
+            } else if (line.includes('PHP Recoverable fatal error')) {
+                level = 'RECOVERABLE_FATAL';
+                type = 'PHP';
+            } else if (line.includes('WordPress database')) {
+                level = 'FATAL';
+                type = 'SQL';
+            }
+
+            // Start new error
+            currentError = {
+                message: '',
+                level,
+                type,
+                test: testName,
+                details: line,
+                log: logFilePath
+            };
+
+            // Set plugin or theme field
+            if (itemType === 'plugin') {
+                currentError.plugin = itemName;
+            } else {
+                currentError.theme = itemName;
+            }
+
+        } else if (playgroundMatch) {
+            // Save previous error if exists
+            if (currentError && currentError.details) {
+                errors.push(currentError);
+            }
+
+            // Create Playground error
+            currentError = {
+                message: '',
+                level: 'FATAL',
+                type: 'PLAYGROUND',
+                test: testName,
+                details: line,
+                log: logPath
+            };
+
+            // Set plugin or theme field
+            if (itemType === 'plugin') {
+                currentError.plugin = itemName;
+            } else {
+                currentError.theme = itemName;
+            }
+
+        } else if (currentError && line.trim()) {
+            // Append to current error details
+            currentError.details += '\n' + line;
+        }
+    }
+
+    // Save last error if exists
+    if (currentError && currentError.details) {
+        errors.push(currentError);
+    }
+
+    // Extract messages from details
+    for (const error of errors) {
+        if (error.type === 'SQL') {
+            // Extract SQL error message
+            const messageMatch = error.details.match(/Error message was: ([^\n]+)/);
+            if (messageMatch) {
+                error.message = messageMatch[1].replace(/<[^>]*>/g, '').split('\n\nBacktrace:')[0];
+            } else {
+                // Try to extract from SQLSTATE error
+                const sqlStateMatch = error.details.match(/SQLSTATE\[.*?\]: (.+?)(?:\n|$)/);
+                if (sqlStateMatch) {
+                    error.message = sqlStateMatch[1].trim();
+                } else {
+                    error.message = error.details;
+                }
+            }
+        } else if (error.type === 'PHP') {
+            // Extract PHP error message (first line after the error type)
+            const match = error.details.match(/PHP [^:]+:\s*(.+?)(?:\n|$)/);
+            if (match) {
+                error.message = match[1].trim();
+            } else {
+                error.message = error.details.split('\n')[0];
+            }
+        } else if (error.type === 'PLAYGROUND') {
+            error.message = error.details;
+        } else {
+            error.message = error.details;
+        }
+    }
+
+    return errors;
+}
+
+/**
+ * Parses a results.json file and extracts errors from test failures with meta.error
+ */
+export function parseResultsJson(
+    resultsPath: string,
+    testName: string,
+    itemType: 'plugin' | 'theme',
+    itemName: string,
+    logFilePath: string
+): ErrorEntry[] {
+    if (!existsSync(resultsPath)) {
+        return [];
+    }
+
+    const content = readFileSync(resultsPath, 'utf-8');
+    let results: TestResults;
+
+    try {
+        results = JSON.parse(content);
+    } catch (e) {
+        console.error(`Failed to parse results.json at ${resultsPath}:`, e);
+        return [];
+    }
+
+    const errors: ErrorEntry[] = [];
+
+    for (const testResult of results.testResults) {
+        for (const assertion of testResult.assertionResults) {
+            // Only extract errors from failed tests with meta.error
+            if (assertion.status === 'failed' && assertion.meta?.error) {
+                const error: ErrorEntry = {
+                    message: assertion.meta.error.message,
+                    level: 'FATAL',
+                    type: 'PLAYGROUND',
+                    test: testName,
+                    details: assertion.meta.error.stack || assertion.meta.error.message,
+                    log: logFilePath
+                };
+
+                // Set plugin or theme field
+                if (itemType === 'plugin') {
+                    error.plugin = itemName;
+                } else {
+                    error.theme = itemName;
+                }
+
+                errors.push(error);
+            }
+        }
+    }
+
+    return errors;
+}
+
+/**
+ * Merges and deduplicates error arrays
+ */
+export function mergeErrors(errors: ErrorEntry[]): ErrorEntry[] {
+    // Simple deduplication based on message + test + type
+    const seen = new Set<string>();
+    const unique: ErrorEntry[] = [];
+
+    for (const error of errors) {
+        const key = `${error.test}:${error.type}:${error.message}`;
+        if (!seen.has(key)) {
+            seen.add(key);
+            unique.push(error);
+        }
+    }
+
+    return unique;
+}
+
+/**
+ * Parses logs for a test and generates error entries
+ */
+export function parseTestLogs(
+    testDirectory: string,
+    testName: string,
+    itemType: 'plugin' | 'theme',
+    itemName: string,
+    logFilePath: string
+): ErrorEntry[] {
+    const errorLogPath = `${testDirectory}/error.log`;
+    const resultsJsonPath = `${testDirectory}/results.json`;
+
+    const errorLogErrors = parseErrorLog(errorLogPath, testName, itemType, itemName, logFilePath);
+    const resultsJsonErrors = parseResultsJson(resultsJsonPath, testName, itemType, itemName, logFilePath);
+
+    const allErrors = [...errorLogErrors, ...resultsJsonErrors];
+    return mergeErrors(allErrors);
+}

--- a/src/test-batch.ts
+++ b/src/test-batch.ts
@@ -3,12 +3,65 @@
  * Use up to MAX_CONCURRENCY workers to execute the tests concurrently.
  */
 import { exec as execCallback } from 'child_process';
-import { existsSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
+import { startVitest, parseCLI } from 'vitest/node';
+import type { Vitest } from 'vitest/node';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 
 const exec = promisify(execCallback);
+
+function formatTestResult(result: Vitest, slug: string): string {
+    const files = result.state.getFiles();
+
+    // Check if all tests passed
+    const allPassed = files.every(file => file.result?.state === 'pass');
+
+    if (allPassed) {
+        return `✅ ${slug} passed`;
+    }
+
+    // Collect failed tests
+    const failedTests: Array<{ name: string; error: string }> = [];
+    let passedTests = 0;
+
+    for (const file of files) {
+        const collectTests = (task: any) => {
+            if (task.type === 'test') {
+                if (task.result?.state === 'pass') {
+                    passedTests++;
+                } else if (task.result?.state === 'fail') {
+                    // Get the first line of the error message
+                    const errorMessage = task.result?.errors?.[0]?.message || 'Unknown error';
+                    const firstLine = errorMessage.split('\n')[0];
+                    failedTests.push({
+                        name: task.name,
+                        error: firstLine
+                    });
+                }
+            }
+
+            // Recursively check nested tasks (suites)
+            if (task.tasks && task.tasks.length > 0) {
+                task.tasks.forEach(collectTests);
+            }
+        };
+
+        // Start from the file itself
+        collectTests(file);
+    }
+
+    const failedCount = failedTests.length;
+
+    // Format output
+    let output = `❌ ${slug} (${failedCount} failed, ${passedTests} passed)`;
+    for (const test of failedTests) {
+        output += `\n  • ${test.name} - ${test.error}`;
+    }
+
+    return output;
+}
 
 // Parse command line arguments.
 const argv = yargs(process.argv.slice(2))
@@ -31,6 +84,14 @@ const argv = yargs(process.argv.slice(2))
     type: 'string',
     description: 'Prefix characters to filter items by',
   })
+  .option('dry-run', {
+    type: 'boolean',
+    description: 'Skip committing and pushing the results',
+  })
+  .option('item-path', {
+    type: 'string',
+    description: 'Path to the item to test',
+  })
   .check((argv) => {
     if (!argv.plugins && !argv.themes) {
       throw new Error('Either --plugins or --themes must be specified');
@@ -46,17 +107,28 @@ const MAX_CONCURRENCY = 8;
 const type = argv.plugins ? 'plugins' : 'themes';
 const limit = argv.limit;
 const prefixChars = argv['prefix-chars'];
+const dryRun = !!argv['dry-run'];
+const itemPath = argv['item-path'];
+const {
+    filter: vitestFilter,
+    options: vitestBaseOptions,
+} = parseCLI(['vitest', 'run', '--reporter=json']);
 
-// Get plugins/themes to test.
-const findResult = await exec(
-    `. ./scripts/lib/log-parser/analyze-json-logs.sh && get_first_n_logs_to_test "${type}" "${limit}" --prefix-chars "${prefixChars}"`,
-    {
-        cwd: rootDir,
-        shell: 'bash',
-        maxBuffer: 100 * 1024 * 1024,
-    }
-);
-const paths = findResult.stdout.split('\n').filter(Boolean);
+let paths: string[] = [];
+if (itemPath) {
+    paths = [resolve(rootDir, itemPath)];
+} else {
+    // Get plugins/themes to test.
+    const findResult = await exec(
+        `. ./scripts/lib/log-parser/analyze-json-logs.sh && get_first_n_logs_to_test "${type}" "${limit}" --prefix-chars "${prefixChars}"`,
+        {
+            cwd: rootDir,
+            shell: 'bash',
+            maxBuffer: 100 * 1024 * 1024,
+        }
+    );
+    paths = findResult.stdout.split('\n').filter(Boolean);
+}
 
 // Update all items in the current batch to prevent them from being picked up by another runner.
 // We will only replace the TIMESTAMP-last-tested.txt file to indicate that the item is being processed.
@@ -64,13 +136,16 @@ for (const path of paths) {
     await exec(`rm ${path}/*-last-tested.txt 2>/dev/null || true`);
     await exec(`echo "Last tested on \$(date +%Y-%m-%d\\ %H:%M:%S)" > "${path}/$(date +%Y%m%d-%H%M%S)-last-tested.txt"`);
 }
-await exec(
-    `. ./scripts/save-data.sh && save_data --add . --message "⏳ testing a batch of ${limit} ${type}" --push`,
-    { cwd: rootDir, shell: 'bash' }
-);
+if (!dryRun) {
+    await exec(
+        `. ./scripts/save-data.sh && save_data --add . --message "⏳ testing a batch of ${limit} ${type}" --push`,
+        { cwd: rootDir, shell: 'bash' }
+    );
+}
 
 // Run tests for plugins/themes batch.
 const pool = new Array(MAX_CONCURRENCY).fill(undefined);
+
 for (const path of paths) {
     const workers = pool.filter((slot) => slot !== undefined);
     if (workers.length >= pool.length) {
@@ -79,36 +154,36 @@ for (const path of paths) {
 
     const workerId = pool.findIndex((slot) => slot === undefined) + 1;
     pool[workerId - 1] = (async () => {
+        const slug = path.split('/').pop() ?? '';
+        const itemType = type === 'plugins' ? 'plugin' : 'theme';
         try {
-            const workerWordpressPath = join(rootDir, 'temp', `worker-${workerId}`);
-            const wordpressPath = join(workerWordpressPath, 'wordpress');
-
-            // Reset WordPress installation if it exists, prepare it otherwise.
-            if (existsSync(join(wordpressPath, '.git'))) {
-                await exec('git reset --hard', { cwd: wordpressPath });
-            } else {
-                await exec(
-                    `./scripts/build-wordpress.sh --output ${workerWordpressPath}`,
-                    {
-                        cwd: rootDir,
-                        env: { ...process.env, PLAYGROUND_PORT: (9400 + workerId).toString() },
-                    }
-                );
+            const errorLogPath = join(path, 'unit-tests', 'error.log');
+            const hostLogDirectory = dirname(errorLogPath);
+            if (!existsSync(hostLogDirectory)) {
+                mkdirSync(hostLogDirectory, { recursive: true });
             }
+            // Ensure the log file exists and is empty
+            writeFileSync(errorLogPath, '');
 
-            // Run tests.
-            const itemType = type === 'plugins' ? 'plugin' : 'theme';
-            const output = await exec(
-                `./scripts/run-tests.sh --${itemType} ${path} --wordpress ${wordpressPath} || true`,
-                {
-                    cwd: rootDir,
-                    env: { ...process.env, PLAYGROUND_PORT: (9400 + workerId).toString() },
-                }
-            );
-
-            console.log(output.stdout);
+            const env: Record<string, string> = {
+              ITEM_SLUG: slug,
+              ITEM_TYPE: itemType,
+              LOG_FILE: errorLogPath,
+              PLAYGROUND_PORT: (9400 + workerId).toString()
+            };
+            return startVitest('test', vitestFilter, {
+                ...vitestBaseOptions,
+                watch: false,
+                reporters: ['verbose'], //['json'],
+                outputFile: join(path, 'unit-tests', 'results.json'),
+                env,
+            }).then((result) => {
+                const output = formatTestResult(result, slug);
+                console.log(output);
+                return result;
+            });
         } catch (err) {
-            console.error(`Failed to run tests for ${path.split('/').pop()}:`, err.message);
+            console.error(`Failed to run tests for ${itemType} ${slug}:`, err.message);
         }
     })().finally(() => {
         pool[workerId - 1] = undefined;
@@ -119,7 +194,9 @@ for (const path of paths) {
 await Promise.all(pool);
 
 // Save data.
-await exec(
-    `. ./scripts/save-data.sh && save_data --add . --message "✅ tested a batch of ${limit} ${type}" --push`,
-    { cwd: rootDir, shell: 'bash' }
-);
+if (!dryRun) {
+    await exec(
+        `. ./scripts/save-data.sh && save_data --add . --message "✅ tested a batch of ${limit} ${type}" --push`,
+        { cwd: rootDir, shell: 'bash' }
+    );
+}

--- a/src/test-batch.ts
+++ b/src/test-batch.ts
@@ -4,10 +4,11 @@
  * Runs all plugin/theme tests using the Playground Tester with up to
  * MAX_CONCURRENCY workers executing tests concurrently.
  *
- * For each item, tests are run in both WASM modes sequentially:
+ * For each item, tests are run in both WASM modes in parallel:
  * 1. Asyncify mode (default Node.js)
  * 2. JSPI mode (with --experimental-wasm-jspi flag)
  *
+ * Each mode gets its own port allocation to avoid conflicts.
  * Results from both modes are aggregated into a single error.json per item.
  */
 import { exec as execCallback, spawn } from 'child_process';
@@ -119,6 +120,7 @@ const argv = yargs(process.argv.slice(2))
 // Configuration.
 const rootDir = join(import.meta.dirname, '..');
 const MAX_CONCURRENCY = 8;
+const BASE_PORT = 9400; // Base port for Playground servers
 const type = argv.plugins ? 'plugins' : 'themes';
 const limit = argv['item-path'] ? 1 : argv.limit;
 const prefixChars = argv['prefix-chars'];
@@ -188,25 +190,26 @@ for (const path of paths) {
                 }
             }
 
-            // Run Asyncify tests
-            const asyncifyResult = await runTestsForMode(
-                path,
-                slug,
-                itemType,
-                'asyncify',
-                workerId,
-                type
-            );
-
-            // Run JSPI tests
-            const jspiResult = await runTestsForMode(
-                path,
-                slug,
-                itemType,
-                'jspi',
-                workerId,
-                type
-            );
+            // Run both modes in parallel with separate port allocations
+            // Asyncify uses workerId, JSPI uses workerId + MAX_CONCURRENCY
+            const [asyncifyResult, jspiResult] = await Promise.all([
+                runTestsForMode(
+                    path,
+                    slug,
+                    itemType,
+                    'asyncify',
+                    workerId, // Port: BASE_PORT + workerId
+                    type
+                ),
+                runTestsForMode(
+                    path,
+                    slug,
+                    itemType,
+                    'jspi',
+                    workerId + MAX_CONCURRENCY, // Port: BASE_PORT + workerId + MAX_CONCURRENCY
+                    type
+                )
+            ]);
 
             // Aggregate results from both modes
             const itemErrorJsonPath = join(path, 'error.json');

--- a/src/test-batch.ts
+++ b/src/test-batch.ts
@@ -1,66 +1,81 @@
 /**
- * Run all plugin tests from "wp-public-data" using the Playground Tester.
- * Use up to MAX_CONCURRENCY workers to execute the tests concurrently.
+ * Batch Test Orchestrator
+ *
+ * Runs all plugin/theme tests using the Playground Tester with up to
+ * MAX_CONCURRENCY workers executing tests concurrently.
+ *
+ * For each item, tests are run in both WASM modes sequentially:
+ * 1. Asyncify mode (default Node.js)
+ * 2. JSPI mode (with --experimental-wasm-jspi flag)
+ *
+ * Results from both modes are aggregated into a single error.json per item.
  */
-import { exec as execCallback } from 'child_process';
-import { dirname, join, resolve } from 'path';
+import { exec as execCallback, spawn } from 'child_process';
+import { join, resolve } from 'path';
 import { promisify } from 'util';
 import yargs from 'yargs';
-import { startVitest, parseCLI } from 'vitest/node';
-import type { Vitest } from 'vitest/node';
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import type { ErrorEntry } from './lib/log-parser.ts';
 
 const exec = promisify(execCallback);
 
-function formatTestResult(result: Vitest, slug: string): string {
-    const files = result.state.getFiles();
+/**
+ * Run tests for a single item in a specific WASM mode by spawning test-runner.ts
+ * with appropriate Node.js flags.
+ */
+async function runTestsForMode(
+    itemPath: string,
+    slug: string,
+    itemType: string,
+    mode: 'asyncify' | 'jspi',
+    workerId: number,
+    type: string
+): Promise<{ success: boolean; exitCode: number }> {
+    return new Promise((resolve) => {
+        const testRunnerPath = join(import.meta.dirname, 'test-runner.ts');
 
-    // Check if all tests passed
-    const allPassed = files.every(file => file.result?.state === 'pass');
+        // Determine Node.js flags based on mode
+        const nodeFlags = [
+            '--experimental-strip-types',
+            '--disable-warning=ExperimentalWarning',
+        ];
 
-    if (allPassed) {
-        return `✅ ${slug} passed`;
-    }
+        if (mode === 'jspi') {
+            // Add JSPI-specific flags
+            nodeFlags.push('--experimental-wasm-jspi');
+            nodeFlags.push('--no-warnings');
+        }
 
-    // Collect failed tests
-    const failedTests: Array<{ name: string; error: string }> = [];
-    let passedTests = 0;
+        const args = [
+            ...nodeFlags,
+            testRunnerPath,
+            `--item-path=${itemPath}`,
+            `--slug=${slug}`,
+            `--item-type=${itemType}`,
+            `--worker-id=${workerId}`,
+            `--type=${type}`,
+        ];
 
-    for (const file of files) {
-        const collectTests = (task: any) => {
-            if (task.type === 'test') {
-                if (task.result?.state === 'pass') {
-                    passedTests++;
-                } else if (task.result?.state === 'fail') {
-                    // Get the first line of the error message
-                    const errorMessage = task.result?.errors?.[0]?.message || 'Unknown error';
-                    const firstLine = errorMessage.split('\n')[0];
-                    failedTests.push({
-                        name: task.name,
-                        error: firstLine
-                    });
-                }
-            }
+        const child = spawn('node', args, {
+            stdio: 'inherit',
+            env: {
+                ...process.env,
+                WASM_MODE: mode,
+            },
+        });
 
-            // Recursively check nested tasks (suites)
-            if (task.tasks && task.tasks.length > 0) {
-                task.tasks.forEach(collectTests);
-            }
-        };
+        child.on('exit', (code) => {
+            resolve({
+                success: code === 0,
+                exitCode: code || 0
+            });
+        });
 
-        // Start from the file itself
-        collectTests(file);
-    }
-
-    const failedCount = failedTests.length;
-
-    // Format output
-    let output = `❌ ${slug} (${failedCount} failed, ${passedTests} passed)`;
-    for (const test of failedTests) {
-        output += `\n  • ${test.name} - ${test.error}`;
-    }
-
-    return output;
+        child.on('error', (err) => {
+            console.error(`[${slug}] Failed to spawn test runner for ${mode}:`, err);
+            resolve({ success: false, exitCode: 1 });
+        });
+    });
 }
 
 // Parse command line arguments.
@@ -105,14 +120,10 @@ const argv = yargs(process.argv.slice(2))
 const rootDir = join(import.meta.dirname, '..');
 const MAX_CONCURRENCY = 8;
 const type = argv.plugins ? 'plugins' : 'themes';
-const limit = argv.limit;
+const limit = argv['item-path'] ? 1 : argv.limit;
 const prefixChars = argv['prefix-chars'];
 const dryRun = !!argv['dry-run'];
 const itemPath = argv['item-path'];
-const {
-    filter: vitestFilter,
-    options: vitestBaseOptions,
-} = parseCLI(['vitest', 'run', '--reporter=json']);
 
 let paths: string[] = [];
 if (itemPath) {
@@ -128,6 +139,15 @@ if (itemPath) {
         }
     );
     paths = findResult.stdout.split('\n').filter(Boolean);
+}
+
+if (paths.length === 0) {
+    console.error('No items to test');
+    process.exit(1);
+} else if (paths.length === 1) {
+    console.log(`Testing ${paths[0].split('/').pop() ?? ''}`);
+} else {
+    console.log(`Testing ${type} ${paths.length} items`);
 }
 
 // Update all items in the current batch to prevent them from being picked up by another runner.
@@ -156,34 +176,84 @@ for (const path of paths) {
     pool[workerId - 1] = (async () => {
         const slug = path.split('/').pop() ?? '';
         const itemType = type === 'plugins' ? 'plugin' : 'theme';
-        try {
-            const errorLogPath = join(path, 'unit-tests', 'error.log');
-            const hostLogDirectory = dirname(errorLogPath);
-            if (!existsSync(hostLogDirectory)) {
-                mkdirSync(hostLogDirectory, { recursive: true });
-            }
-            // Ensure the log file exists and is empty
-            writeFileSync(errorLogPath, '');
 
-            const env: Record<string, string> = {
-              ITEM_SLUG: slug,
-              ITEM_TYPE: itemType,
-              LOG_FILE: errorLogPath,
-              PLAYGROUND_PORT: (9400 + workerId).toString()
-            };
-            return startVitest('test', vitestFilter, {
-                ...vitestBaseOptions,
-                watch: false,
-                reporters: ['verbose'], //['json'],
-                outputFile: join(path, 'unit-tests', 'results.json'),
-                env,
-            }).then((result) => {
-                const output = formatTestResult(result, slug);
-                console.log(output);
-                return result;
-            });
-        } catch (err) {
-            console.error(`Failed to run tests for ${itemType} ${slug}:`, err.message);
+        try {
+            // Clean up old test directories before running new tests
+            // Note: *-boot directories are from legacy testing approach, can be removed in future
+            const oldDirs = ['unit-tests', 'asyncify', 'jspi', 'ast-sqlite-boot', 'jspi-boot', 'asyncify-boot'];
+            for (const dir of oldDirs) {
+                const dirPath = join(path, dir);
+                if (existsSync(dirPath)) {
+                    rmSync(dirPath, { recursive: true, force: true });
+                }
+            }
+
+            // Run Asyncify tests
+            const asyncifyResult = await runTestsForMode(
+                path,
+                slug,
+                itemType,
+                'asyncify',
+                workerId,
+                type
+            );
+
+            // Run JSPI tests
+            const jspiResult = await runTestsForMode(
+                path,
+                slug,
+                itemType,
+                'jspi',
+                workerId,
+                type
+            );
+
+            // Aggregate results from both modes
+            const itemErrorJsonPath = join(path, 'error.json');
+            let allErrors: ErrorEntry[] = [];
+
+            // Read existing errors if file exists (for other test types)
+            if (existsSync(itemErrorJsonPath)) {
+                try {
+                    const existingContent = readFileSync(itemErrorJsonPath, 'utf-8');
+                    const existingErrors = JSON.parse(existingContent) as ErrorEntry[];
+                    // Filter out old asyncify/jspi/unit-tests errors
+                    allErrors = existingErrors.filter(e =>
+                        e.test !== 'asyncify' &&
+                        e.test !== 'jspi' &&
+                        e.test !== 'unit-tests'
+                    );
+                } catch (e) {
+                    console.error(`[${slug}] Failed to parse existing error.json:`, e);
+                }
+            }
+
+            // Add errors from asyncify mode
+            const asyncifyErrorPath = join(path, 'asyncify', 'error.json');
+            if (existsSync(asyncifyErrorPath)) {
+                try {
+                    const asyncifyErrors = JSON.parse(readFileSync(asyncifyErrorPath, 'utf-8')) as ErrorEntry[];
+                    allErrors.push(...asyncifyErrors);
+                } catch (e) {
+                    console.error(`[${slug}] Failed to read asyncify error.json:`, e);
+                }
+            }
+
+            // Add errors from jspi mode
+            const jspiErrorPath = join(path, 'jspi', 'error.json');
+            if (existsSync(jspiErrorPath)) {
+                try {
+                    const jspiErrors = JSON.parse(readFileSync(jspiErrorPath, 'utf-8')) as ErrorEntry[];
+                    allErrors.push(...jspiErrors);
+                } catch (e) {
+                    console.error(`[${slug}] Failed to read jspi error.json:`, e);
+                }
+            }
+
+            // Write aggregated error.json
+            writeFileSync(itemErrorJsonPath, JSON.stringify(allErrors, null, 2));
+        } catch (err: any) {
+            console.error(`[${slug}] Failed to run tests:`, err.message);
         }
     })().finally(() => {
         pool[workerId - 1] = undefined;

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -1,0 +1,221 @@
+/**
+ * Test Runner - Executes vitest for a single item
+ *
+ * This file runs in a spawned process with specific Node.js flags that
+ * determine the WASM mode (JSPI vs Asyncify):
+ * - With --experimental-wasm-jspi: JSPI mode
+ * - Without: Asyncify mode
+ *
+ * The mode is automatically detected at runtime via wasm-feature-detect.
+ */
+
+import { join, dirname } from 'path';
+import yargs from 'yargs';
+import { startVitest, parseCLI } from 'vitest/node';
+import type { Vitest } from 'vitest/node';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { parseTestLogs } from './lib/log-parser.ts';
+import { jspi } from 'wasm-feature-detect';
+
+function formatTestResult(result: Vitest, slug: string, mode: string): string {
+    const files = result.state.getFiles();
+
+    // Check if all tests passed
+    const allPassed = files.every(file => file.result?.state === 'pass');
+
+    if (allPassed) {
+        return `✅ ${slug} (${mode}) passed`;
+    }
+
+    // Collect failed tests
+    const failedTests: Array<{ name: string; error: string }> = [];
+    let passedTests = 0;
+
+    for (const file of files) {
+        const collectTests = (task: any) => {
+            if (task.type === 'test') {
+                if (task.result?.state === 'pass') {
+                    passedTests++;
+                } else if (task.result?.state === 'fail') {
+                    // Get the first line of the error message
+                    const errorMessage = task.result?.errors?.[0]?.message || 'Unknown error';
+                    const firstLine = errorMessage.split('\n')[0];
+                    failedTests.push({
+                        name: task.name,
+                        error: firstLine
+                    });
+                }
+            }
+
+            // Recursively check nested tasks (suites)
+            if (task.tasks && task.tasks.length > 0) {
+                task.tasks.forEach(collectTests);
+            }
+        };
+
+        // Start from the file itself
+        collectTests(file);
+    }
+
+    const failedCount = failedTests.length;
+
+    // Format output
+    let output = `❌ ${slug} (${mode}) (${failedCount} failed, ${passedTests} passed)`;
+    for (const test of failedTests) {
+        output += `\n  • ${test.name} - ${test.error}`;
+    }
+
+    return output;
+}
+
+// Parse command line arguments
+const argv = yargs(process.argv.slice(2))
+    .option('item-path', {
+        type: 'string',
+        description: 'Path to the item to test',
+        demandOption: true,
+    })
+    .option('slug', {
+        type: 'string',
+        description: 'Item slug',
+        demandOption: true,
+    })
+    .option('item-type', {
+        type: 'string',
+        description: 'Item type (plugin or theme)',
+        demandOption: true,
+    })
+    .option('worker-id', {
+        type: 'number',
+        description: 'Worker ID for port assignment',
+        demandOption: true,
+    })
+    .option('type', {
+        type: 'string',
+        description: 'Type (plugins or themes)',
+        demandOption: true,
+        choices: ['plugins', 'themes'],
+    })
+    .help()
+    .parseSync();
+
+const itemPath = argv['item-path'];
+const slug = argv.slug;
+const itemType = argv['item-type'];
+const workerId = argv['worker-id'];
+const type = argv.type;
+
+// Detect the WASM mode based on runtime capabilities
+const detectedJspi = await jspi();
+const mode = detectedJspi ? 'jspi' : 'asyncify';
+
+// Verify expected mode matches detected mode (for debugging)
+if (process.env.WASM_MODE && process.env.WASM_MODE !== mode) {
+    console.warn(`[${slug}] Warning: Expected ${process.env.WASM_MODE} but detected ${mode}`);
+}
+
+// Setup test directory for this mode (asyncify/ or jspi/)
+const testDirectory = join(itemPath, mode);
+const errorLogPath = join(testDirectory, 'error.log');
+
+if (!existsSync(testDirectory)) {
+    mkdirSync(testDirectory, { recursive: true });
+}
+
+// Initialize empty log file
+writeFileSync(errorLogPath, '');
+
+// Configure environment for vitest
+const env: Record<string, string> = {
+    ITEM_SLUG: slug,
+    ITEM_TYPE: itemType,
+    LOG_FILE: errorLogPath,
+    PLAYGROUND_PORT: (9400 + workerId).toString()
+};
+
+// Parse vitest CLI options
+const { filter: vitestFilter, options: vitestBaseOptions } = parseCLI(['vitest', 'run']);
+
+// Suppress all vitest output by intercepting stdout/stderr
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+process.stdout.write = (): boolean => true;
+process.stderr.write = (): boolean => true;
+
+// Run vitest silently
+try {
+    const result = await startVitest('test', vitestFilter, {
+        ...vitestBaseOptions,
+        watch: false,
+        reporters: [],
+        env,
+    });
+
+    // Restore stdout/stderr immediately after vitest completes
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+
+    if (!result) {
+        console.error(`[${slug}] Failed to start vitest`);
+        process.exit(1);
+    }
+
+    // Manually write JSON results file (avoids vitest's "JSON report written" message)
+    // Format matches what parseTestLogs expects
+    const testFiles = result.state.getFiles();
+    const resultData = {
+        success: testFiles.every(file => file.result?.state === 'pass'),
+        testResults: testFiles.map(file => ({
+            name: file.name,
+            status: file.result?.state,
+            assertionResults: file.tasks.map(task => ({
+                ancestorTitles: task.suite ? [task.suite.name] : [],
+                fullName: task.name,
+                status: task.result?.state || 'pending',
+                title: task.name,
+                failureMessages: task.result?.errors?.map(e => e.message) || [],
+                meta: task.meta
+            }))
+        }))
+    };
+    writeFileSync(join(testDirectory, 'results.json'), JSON.stringify(resultData, null, 2));
+
+    // Format and display test results
+    const output = formatTestResult(result, slug, mode);
+    console.log(output);
+
+    // Parse error logs and generate error.json
+    try {
+        const firstLetter = slug.charAt(0);
+        const logFilePath = `/logs/${type}/${firstLetter}/${slug}/error.json`;
+
+        // Parse test logs
+        const errors = parseTestLogs(
+            testDirectory,
+            mode, // Use mode as test name instead of 'unit-tests'
+            itemType as 'plugin' | 'theme',
+            slug,
+            logFilePath
+        );
+
+        // Write error.json for this mode
+        const testErrorJsonPath = join(testDirectory, 'error.json');
+        writeFileSync(testErrorJsonPath, JSON.stringify(errors, null, 2));
+    } catch (err: any) {
+        console.error(`[${slug}] Failed to parse logs:`, err.message);
+    }
+
+    // Determine exit code based on test results
+    const files = result.state.getFiles();
+    const allPassed = files.every(file => file.result?.state === 'pass');
+
+    // Exit with appropriate code
+    process.exit(allPassed ? 0 : 1);
+
+} catch (err: any) {
+    // Restore stdout/stderr in case of error
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    console.error(`[${slug}] Failed to run tests:`, err.message);
+    process.exit(1);
+}

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -126,6 +126,10 @@ if (!existsSync(testDirectory)) {
 writeFileSync(errorLogPath, '');
 
 // Configure environment for vitest
+// Port allocation: BASE_PORT (9400) + workerId
+// When running modes in parallel:
+//   - Asyncify uses workerIds 1 to MAX_CONCURRENCY
+//   - JSPI uses workerIds (MAX_CONCURRENCY + 1) to (MAX_CONCURRENCY * 2)
 const env: Record<string, string> = {
     ITEM_SLUG: slug,
     ITEM_TYPE: itemType,

--- a/src/test/unit/wordpress.spec.ts
+++ b/src/test/unit/wordpress.spec.ts
@@ -128,21 +128,21 @@ describe('Unit tests', () => {
             bootError = error as Error;
         }
     });
-    afterAll(async ({ suite }) => {
+    afterAll(async () => {
         if (server) {
             await server.close();
-        }
-        if (bootError && suite) {
-            suite.meta['error'] = {
-                message: bootError?.message,
-                stack: bootError?.stack,
-                cause: bootError?.cause,
-            };
         }
     });
 
     describe('boot', () => {
         it('should boot without errors', ({ task }) => {
+            if (bootError) {
+                task.meta['error'] = {
+                    message: bootError?.message,
+                    stack: bootError?.stack,
+                    cause: bootError?.cause,
+                };
+            }
             expect(bootError).toBeUndefined();
         });
     });

--- a/src/test/unit/wordpress.spec.ts
+++ b/src/test/unit/wordpress.spec.ts
@@ -1,27 +1,49 @@
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { runCLI } from '@wp-playground/cli';
 import type { RunCLIServer } from '@wp-playground/cli';
-import { login, type Blueprint } from '@wp-playground/blueprints';
+import { type Blueprint } from '@wp-playground/blueprints';
 import type { PHPRequest, PHPResponse } from '@php-wasm/universal';
 import { phpVar } from '@php-wasm/util';
 import { errorLogPath as vfsErrorLogPath } from '@php-wasm/logger';
 import path from 'path';
-import fs from 'fs';
+import { writeFileSync } from 'fs';
+
+interface Env {
+    ITEM_TYPE?: string;
+    ITEM_SLUG?: string;
+    LOG_FILE?: string;
+    PLAYGROUND_PORT?: string;
+}
+
+const env = process.env as Env;
+
+// write env vars to a temp file
+writeFileSync(path.resolve(process.cwd(), 'temp', 'env.json'), JSON.stringify(env, null, 2));
+
+// write process.env to a temp file
+writeFileSync(path.resolve(process.cwd(), 'temp', 'process.env.json'), JSON.stringify(process.env, null, 2));
 
 interface TestArgs {
     plugin?: string;
     theme?: string;
+    hostErrorLogPath: string;
+    playgroundPort?: number;
 }
 
 const args: TestArgs = {
-    plugin: process.env.WP_TEST_PLUGIN,
-    theme: process.env.WP_TEST_THEME,
+    hostErrorLogPath: path.resolve(process.cwd(), 'temp', 'error.log'),
 };
-
-const phpArgs: TestArgs = {
-    plugin: phpVar(args.plugin),
-    theme: phpVar(args.theme),
-};
+if (env.ITEM_TYPE === 'theme') {
+    args.theme = env.ITEM_SLUG;
+} else if (env.ITEM_TYPE === 'plugin') {
+    args.plugin = env.ITEM_SLUG;
+}
+if (env.LOG_FILE) {
+    args.hostErrorLogPath = env.LOG_FILE;
+}
+if (env.PLAYGROUND_PORT) {
+    args.playgroundPort = parseInt(env.PLAYGROUND_PORT);
+}
 
 function getBlueprint(args: TestArgs) : Blueprint {
     const blueprint: Blueprint = {
@@ -34,7 +56,16 @@ function getBlueprint(args: TestArgs) : Blueprint {
         ],
     };
     if (args.plugin) {
-        blueprint.plugins = [args.plugin];
+        blueprint.steps.push({
+            "step": "installPlugin",
+            "pluginData": {
+                "resource": "wordpress.org/plugins",
+                "slug": args.plugin,
+            },
+            "options": {
+                "activate": true
+            }
+        });
     }
     if (args.theme) {
         blueprint.steps.push({
@@ -72,19 +103,22 @@ describe('Unit tests', () => {
     let bootError: Error | undefined;
     beforeAll(async () => {
         try {
-            const hostErrorLogPath = path.resolve(process.cwd(), 'error.log');
-            fs.writeFileSync(hostErrorLogPath, '');
+            const blueprint = getBlueprint(args);
+            console.log(JSON.stringify(blueprint, null, 2));
+            // write blueprint to a temp file
+            writeFileSync(path.resolve(process.cwd(), 'temp', 'blueprint.json'), JSON.stringify(blueprint, null, 2));
             cli = await runCLI({
                 command: 'server',
-                blueprint: getBlueprint(args),
+                blueprint,
                 quiet: true,
                 mount: [
                     {
-                        hostPath: hostErrorLogPath,
+                        hostPath: args.hostErrorLogPath,
                         vfsPath: vfsErrorLogPath,
                     }
                 ],
                 internalCookieStore: true,
+                port: args.playgroundPort,
             });
             server = cli.server;
             playground = cli.playground;
@@ -94,15 +128,22 @@ describe('Unit tests', () => {
             bootError = error as Error;
         }
     });
-    afterAll(async () => {
+    afterAll(async ({ suite }) => {
         if (server) {
             await server.close();
+        }
+        if (bootError && suite) {
+            suite.meta['error'] = {
+                message: bootError?.message,
+                stack: bootError?.stack,
+                cause: bootError?.cause,
+            };
         }
     });
 
     describe('boot', () => {
-        it('should boot without errors', () => {
-            expect(bootError?.message).toBeUndefined();
+        it('should boot without errors', ({ task }) => {
+            expect(bootError).toBeUndefined();
         });
     });
 

--- a/src/test/unit/wordpress.spec.ts
+++ b/src/test/unit/wordpress.spec.ts
@@ -103,13 +103,9 @@ describe('Unit tests', () => {
     let bootError: Error | undefined;
     beforeAll(async () => {
         try {
-            const blueprint = getBlueprint(args);
-            console.log(JSON.stringify(blueprint, null, 2));
-            // write blueprint to a temp file
-            writeFileSync(path.resolve(process.cwd(), 'temp', 'blueprint.json'), JSON.stringify(blueprint, null, 2));
             cli = await runCLI({
                 command: 'server',
-                blueprint,
+                blueprint: getBlueprint(args),
                 quiet: true,
                 mount: [
                     {

--- a/src/test/unit/wordpress.spec.ts
+++ b/src/test/unit/wordpress.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import { runCLI } from '@wp-playground/cli';
+import type { RunCLIServer } from '@wp-playground/cli';
+import { login, type Blueprint } from '@wp-playground/blueprints';
+import type { PHPRequest, PHPResponse } from '@php-wasm/universal';
+import { phpVar } from '@php-wasm/util';
+import { errorLogPath as vfsErrorLogPath } from '@php-wasm/logger';
+import path from 'path';
+import fs from 'fs';
+
+interface TestArgs {
+    plugin?: string;
+    theme?: string;
+}
+
+const args: TestArgs = {
+    plugin: process.env.WP_TEST_PLUGIN,
+    theme: process.env.WP_TEST_THEME,
+};
+
+const phpArgs: TestArgs = {
+    plugin: phpVar(args.plugin),
+    theme: phpVar(args.theme),
+};
+
+function getBlueprint(args: TestArgs) : Blueprint {
+    const blueprint: Blueprint = {
+        extraLibraries: [ 'wp-cli' ],
+        steps: [
+            {
+                step: 'login',
+                username: 'admin',
+            }
+        ],
+    };
+    if (args.plugin) {
+        blueprint.plugins = [args.plugin];
+    }
+    if (args.theme) {
+        blueprint.steps.push({
+            "step": "installTheme",
+            "themeData": {
+                "resource": "wordpress.org/themes",
+                "slug": args.theme
+            },
+            "options": {
+                "activate": true,
+                "importStarterContent": true
+            }
+        });
+    }
+
+    return blueprint;
+}
+
+const requestFollowRedirects = async (playground: RunCLIServer['playground'], request: PHPRequest) : Promise<PHPResponse> => {
+    const response = await playground.request(request);
+    if (response.httpStatusCode >= 300 && response.httpStatusCode < 400 && response.headers.location) {
+        return requestFollowRedirects(playground, {
+            url: response.headers.location[0],
+        });
+    }
+    return response;
+}
+
+describe('Unit tests', () => {
+    let cli: RunCLIServer;
+    let server: RunCLIServer['server'];
+    let playground: RunCLIServer['playground'];
+    let documentRoot: string;
+    let absoluteUrl: string;
+    let bootError: Error | undefined;
+    beforeAll(async () => {
+        try {
+            const hostErrorLogPath = path.resolve(process.cwd(), 'error.log');
+            fs.writeFileSync(hostErrorLogPath, '');
+            cli = await runCLI({
+                command: 'server',
+                blueprint: getBlueprint(args),
+                quiet: true,
+                mount: [
+                    {
+                        hostPath: hostErrorLogPath,
+                        vfsPath: vfsErrorLogPath,
+                    }
+                ],
+                internalCookieStore: true,
+            });
+            server = cli.server;
+            playground = cli.playground;
+            documentRoot = await playground.documentRoot;
+            absoluteUrl = await playground.absoluteUrl;
+        } catch (error) {
+            bootError = error as Error;
+        }
+    });
+    afterAll(async () => {
+        if (server) {
+            await server.close();
+        }
+    });
+
+    describe('boot', () => {
+        it('should boot without errors', () => {
+            expect(bootError?.message).toBeUndefined();
+        });
+    });
+
+    describe.skipIf(bootError)('wordpress', () => {
+        it('create a post', async () => {
+            const postTitle = 'Test Post Title';
+            const postContent = 'This is a test post content';
+            const result = await playground.run({
+                code: `<?php
+                require_once "${documentRoot}/wp-load.php";
+                $post_id = wp_insert_post([
+                    'post_title' => ${phpVar(postTitle)},
+                    'post_content' => ${phpVar(postContent)},
+                ]);
+                $post = get_post($post_id);
+                echo json_encode($post);
+                ?>`
+            });
+
+            const post = result.json;
+            expect(post.post_title).toBe(postTitle);
+            expect(post.post_content).toBe(postContent);
+        });
+        it('should load wp-admin', async () => {
+            const response = await requestFollowRedirects(
+                playground,
+                {
+                    url: '/wp-admin/',
+                    method: 'GET'
+                }
+            );
+            expect(response.httpStatusCode).toBe(200);
+            expect(response.text).toContain('<h1>Dashboard</h1>');
+        });
+    });
+
+    describe.skipIf(!args.plugin || bootError)('plugin', () => {
+        it('should be active', async () => {
+            const r = await playground.cli([
+                'php',
+                '/tmp/wp-cli.phar',
+                `--path=${documentRoot}`,
+                'plugin',
+                'list',
+                '--status=active',
+                '--field=name',
+                '--format=json'
+            ]);
+            expect(JSON.parse(await r.stdoutText)).toContain(args.plugin);
+        });
+    });
+
+    describe.skipIf(!args.theme || bootError)('theme', () => {
+        it('should be active', async () => {
+            const r = await playground.cli([
+                'php',
+                '/tmp/wp-cli.phar',
+                `--path=${documentRoot}`,
+                'theme',
+                'list',
+                '--status=active',
+                    '--field=name',
+                    '--format=json'
+            ]);
+            expect(JSON.parse(await r.stdoutText)).toMatchObject([args.theme]);
+        });
+    });
+});
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,53 +1,4 @@
 import { defineConfig } from 'vitest/config';
-import { JsonReporter } from 'vitest/reporters';
-import yargs from 'yargs';
-
-const forwardedIndex = process.argv.indexOf('--');
-
-if (forwardedIndex >= 0) {
-  const forwarded = process.argv.slice(forwardedIndex + 1);
-  if (forwarded.length > 0) {
-    const parsed = yargs(forwarded)
-      .option('plugin', {
-        type: 'string',
-        describe: 'Name of the plugin to test',
-      })
-      .option('theme', {
-        type: 'string',
-        describe: 'Name of the theme to test',
-      })
-      .parseSync() as { plugin?: string; theme?: string };
-
-    if (parsed.plugin) {
-      process.env.WP_TEST_PLUGIN = parsed.plugin;
-    }
-
-    if (parsed.theme) {
-      process.env.WP_TEST_THEME = parsed.theme;
-    }
-  }
-}
-
-class PlaygroundJsonReporter extends JsonReporter {
-  constructor(options: ConstructorParameters<typeof JsonReporter>[0] = {}) {
-    super(options);
-  }
-
-  async writeReport(report: string) {
-    let enhancedReport = report;
-
-    try {
-      const data = JSON.parse(report) as Record<string, unknown>;
-      data.test = true;
-      enhancedReport = JSON.stringify(data);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.ctx?.logger.warn?.(`Failed to extend Vitest JSON report: ${message}`);
-    }
-
-    await super.writeReport(enhancedReport);
-  }
-}
 
 export default defineConfig({
   test: {
@@ -64,10 +15,7 @@ export default defineConfig({
       '**/wp-public-data/**',
       '**/logs/**',
     ],
-    reporters: [
-      'default',
-      new PlaygroundJsonReporter({ outputFile: 'test-results/vitest-report.json' }),
-    ],
+    outputFile: 'temp/test-results',
   },
   esbuild: {
     target: 'node23',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,89 @@
+import { defineConfig } from 'vitest/config';
+import { JsonReporter } from 'vitest/reporters';
+import yargs from 'yargs';
+
+const forwardedIndex = process.argv.indexOf('--');
+
+if (forwardedIndex >= 0) {
+  const forwarded = process.argv.slice(forwardedIndex + 1);
+  if (forwarded.length > 0) {
+    const parsed = yargs(forwarded)
+      .option('plugin', {
+        type: 'string',
+        describe: 'Name of the plugin to test',
+      })
+      .option('theme', {
+        type: 'string',
+        describe: 'Name of the theme to test',
+      })
+      .parseSync() as { plugin?: string; theme?: string };
+
+    if (parsed.plugin) {
+      process.env.WP_TEST_PLUGIN = parsed.plugin;
+    }
+
+    if (parsed.theme) {
+      process.env.WP_TEST_THEME = parsed.theme;
+    }
+  }
+}
+
+class PlaygroundJsonReporter extends JsonReporter {
+  constructor(options: ConstructorParameters<typeof JsonReporter>[0] = {}) {
+    super(options);
+  }
+
+  async writeReport(report: string) {
+    let enhancedReport = report;
+
+    try {
+      const data = JSON.parse(report) as Record<string, unknown>;
+      data.test = true;
+      enhancedReport = JSON.stringify(data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.ctx?.logger.warn?.(`Failed to extend Vitest JSON report: ${message}`);
+    }
+
+    await super.writeReport(enhancedReport);
+  }
+}
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/test/**/*.spec.ts'],
+    testTimeout: 120000, // 2 minutes
+    hookTimeout: 120000, // 2 minutes
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/data/**',
+      '**/temp/**',
+      '**/wordpress-develop/**',
+      '**/wp-public-data/**',
+      '**/logs/**',
+    ],
+    reporters: [
+      'default',
+      new PlaygroundJsonReporter({ outputFile: 'test-results/vitest-report.json' }),
+    ],
+  },
+  esbuild: {
+    target: 'node23',
+  },
+  server: {
+    watch: {
+      ignored: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/data/**',
+        '**/temp/**',
+        '**/wordpress-develop/**',
+        '**/wp-public-data/**',
+        '**/logs/**',
+      ],
+    },
+  },
+});
+


### PR DESCRIPTION
## Motivation for the change, related issues

The previous testing infrastructure only supported basic boot tests. This refactor introduces Vitest as the test framework, enabling us to write comprehensive integration tests for WordPress plugins and themes.

## Implementation details

**Test Framework:**
- Uses Vitest to run WordPress integration tests via `@wp-playground/cli`
- Test file: `src/test/unit/wordpress.spec.ts` - validates boot, post creation, wp-admin loading, plugin/theme activation
- Configuration: `vitest.config.ts` with 2-minute timeouts for WordPress installation
- `src/test-runner.ts` spawns vitest with mode-specific Node.js flags
  - **Asyncify mode:** Default Node.js (stable)
  - **JSPI mode:** Node.js with `--experimental-wasm-jspi` flag
- Both modes run in parallel for each plugin/theme

**Error Parser** (`src/lib/log-parser.ts`):
- Extracts errors from vitest results.json and error.log files
- Categorizes: PHP errors (Fatal/Warning/Notice/etc.), SQL errors, Playground runtime errors
- Deduplicates and outputs structured error.json

## Testing instructions

**Run unit tests:**
```bash
npm test
```

**Test single item:**
```bash
npm run test:batch -- --plugins --dry-run --item-path=data/logs/plugins/a/akismet
```

**Test a batch:**
```bash
npm run test:batch -- --plugins --limit=10 --dry-run
```

**Expected output:**
```
Testing akismet
✅ akismet (asyncify) passed
✅ akismet (jspi) passed
```

<img width="1890" height="935" alt="Screenshot 2025-11-04 at 14 44 45" src="https://github.com/user-attachments/assets/27dc6f0f-610f-4750-9b39-6230c7c001d5" />

## TODO

- [ ] Remove unused .sh files
- [ ] Implement PR tests
